### PR TITLE
fix: refactor client creation

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Client struct {
+	apiKey                    string
 	Config                    Config
 	p256PublicKeyUncompressed []byte
 	p256PublicKeyCompressed   []byte
@@ -42,26 +43,26 @@ type clientRequest struct {
 	runToken string
 }
 
-func (c *Client) makeClient() (*Client, error) {
+func (c *Client) makeClient() error {
 	keysResponse, err := c.getPublicKey()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	decodedPublicKeyUncompressed, err := base64.StdEncoding.DecodeString(keysResponse.EcdhP256KeyUncompressed)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding uncompressed public key %w", err)
+		return fmt.Errorf("error decoding uncompressed public key %w", err)
 	}
 
 	decodedPublicKeyCompressed, err := base64.StdEncoding.DecodeString(keysResponse.EcdhP256Key)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding compressed public key %w", err)
+		return fmt.Errorf("error decoding compressed public key %w", err)
 	}
 
 	c.p256PublicKeyUncompressed = decodedPublicKeyUncompressed
 	c.p256PublicKeyCompressed = decodedPublicKeyCompressed
 
-	return c, nil
+	return nil
 }
 
 func (c *Client) getPublicKey() (KeysResponse, error) {
@@ -127,7 +128,7 @@ func (c *Client) makeRequest(url string, method string, body []byte, runToken st
 		url:      url,
 		method:   method,
 		body:     body,
-		apiKey:   c.Config.apiKey,
+		apiKey:   c.apiKey,
 		runToken: runToken,
 	})
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -43,7 +43,7 @@ type clientRequest struct {
 	runToken string
 }
 
-func (c *Client) makeClient() error {
+func (c *Client) initClient() error {
 	keysResponse, err := c.getPublicKey()
 	if err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -66,7 +66,7 @@ func (c *Client) initClient() error {
 }
 
 func (c *Client) getPublicKey() (KeysResponse, error) {
-	publicKeyURL := fmt.Sprintf("%s/cages/key", c.Config.evAPIURL)
+	publicKeyURL := fmt.Sprintf("%s/cages/key", c.Config.EvAPIURL)
 
 	keys, err := c.makeRequest(publicKeyURL, "GET", nil, "")
 	if err != nil {
@@ -87,7 +87,7 @@ func (c *Client) createRunToken(functionName string, payload interface{}) (RunTo
 		return RunTokenResponse{}, fmt.Errorf("Error parsing payload as json %w", err)
 	}
 
-	runTokenURL := fmt.Sprintf("%s/v2/functions/%s/run-token", c.Config.evAPIURL, functionName)
+	runTokenURL := fmt.Sprintf("%s/v2/functions/%s/run-token", c.Config.EvAPIURL, functionName)
 
 	runToken, err := c.makeRequest(runTokenURL, "POST", pBytes, "")
 	if err != nil {
@@ -108,7 +108,7 @@ func (c *Client) runFunction(functionName string, payload interface{}, runToken 
 		return FunctionRunResponse{}, fmt.Errorf("Error parsing payload as json %w", err)
 	}
 
-	runFunctionURL := fmt.Sprintf("%s/%s", c.Config.functionRunURL, functionName)
+	runFunctionURL := fmt.Sprintf("%s/%s", c.Config.FunctionRunURL, functionName)
 
 	resp, err := c.makeRequest(runFunctionURL, "POST", pBytes, runToken)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -5,10 +5,10 @@ import (
 )
 
 type Config struct {
-	evervaultCaURL string
-	relayURL       string
-	functionRunURL string
-	evAPIURL       string
+	EvervaultCaURL string
+	RelayURL       string
+	FunctionRunURL string
+	EvAPIURL       string
 }
 
 func MakeConfig() Config {
@@ -33,9 +33,9 @@ func MakeConfig() Config {
 	}
 
 	return Config{
-		evervaultCaURL: caURL,
-		relayURL:       evRelayURL,
-		functionRunURL: evFunctionRun,
-		evAPIURL:       evAPIURL,
+		EvervaultCaURL: caURL,
+		RelayURL:       evRelayURL,
+		FunctionRunURL: evFunctionRun,
+		EvAPIURL:       evAPIURL,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -5,18 +5,13 @@ import (
 )
 
 type Config struct {
-	apiKey         string
 	evervaultCaURL string
-	RelayURL       string
+	relayURL       string
 	functionRunURL string
 	evAPIURL       string
 }
 
-func MakeConfig(apiKey string) (Config, error) {
-	if apiKey == "" {
-		return Config{}, ErrAPIKeyRequired
-	}
-
+func MakeConfig() Config {
 	caURL := os.Getenv("EV_CA_URL")
 	if caURL == "" {
 		caURL = "https://ca.evervault.com"
@@ -38,10 +33,9 @@ func MakeConfig(apiKey string) (Config, error) {
 	}
 
 	return Config{
-		apiKey:         apiKey,
 		evervaultCaURL: caURL,
-		RelayURL:       evRelayURL,
+		relayURL:       evRelayURL,
 		functionRunURL: evFunctionRun,
 		evAPIURL:       evAPIURL,
-	}, nil
+	}
 }

--- a/evervault.go
+++ b/evervault.go
@@ -116,7 +116,7 @@ func (c *Client) encryptValue(value interface{}, aesKey []byte, ephemeralPublicK
 
 // Will return a http.Client that is configured to use the Evervault Relay as a proxy.
 func (c *Client) OutboundRelayClient() (*http.Client, error) {
-	caCertResponse, err := c.makeRequest(c.Config.evervaultCaURL, "GET", nil, "")
+	caCertResponse, err := c.makeRequest(c.Config.EvervaultCaURL, "GET", nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/evervault.go
+++ b/evervault.go
@@ -49,7 +49,7 @@ func MakeCustomClient(apiKey string, config Config) (*Client, error) {
 		Config: config,
 	}
 
-	err := client.makeClient()
+	err := client.initClient()
 	if err != nil {
 		return nil, err
 	}

--- a/evervault.go
+++ b/evervault.go
@@ -24,20 +24,37 @@ var (
 	ErrInvalidDataType                 = errors.New("Error: Invalid datatype")
 )
 
-// InitClient creates a new Client instance if an API key is provided. The client
+// MakeClient creates a new Client instance if an API key is provided. The client
 // will connect to Evervaults API to retrieve the public keys from your Evervault App.
 //
 // If an apiKey is not passed then ErrAPIKeyRequired is returned. If the client cannot
 // be created then nil will be returned.
-func (c *Client) InitClient(apiKey string) (*Client, error) {
-	config, err := MakeConfig(apiKey)
+func MakeClient(apiKey string) (*Client, error) {
+	config := MakeConfig()
+	return MakeCustomClient(apiKey, config)
+}
+
+// MakeCustomClient creates a new Client instance but can be specified with a Config. The client
+// will connect to Evervaults API to retrieve the public keys from your Evervault App.
+//
+// If an apiKey is not passed then ErrAPIKeyRequired is returned. If the client cannot
+// be created then nil will be returned.
+func MakeCustomClient(apiKey string, config Config) (*Client, error) {
+	if apiKey == "" {
+		return nil, ErrAPIKeyRequired
+	}
+
+	client := &Client{
+		apiKey: apiKey,
+		Config: config,
+	}
+
+	err := client.makeClient()
 	if err != nil {
 		return nil, err
 	}
 
-	c.Config = config
-
-	return c.makeClient()
+	return client, nil
 }
 
 // Encrypt encrypts the value passed to it using the Evervault Encryption Scheme.

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -199,9 +199,11 @@ func mockedClient(server *httptest.Server) *evervault.Client {
 
 	config := evervault.MakeConfig()
 	client, err := evervault.MakeCustomClient("test_api_key", config)
+
 	if err != nil {
 		panic(err)
 	}
+
 	return client
 }
 

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -198,8 +198,8 @@ func mockedClient(server *httptest.Server) *evervault.Client {
 	os.Setenv("EV_FUNCTION_RUN_URL", server.URL)
 
 	config := evervault.MakeConfig()
-	client, err := evervault.MakeCustomClient("test_api_key", config)
 
+	client, err := evervault.MakeCustomClient("test_api_key", config)
 	if err != nil {
 		panic(err)
 	}

--- a/relay.go
+++ b/relay.go
@@ -20,7 +20,7 @@ func (c *Client) relayClient(caCert []byte) (*http.Client, error) {
 }
 
 func (c *Client) transport(caCert []byte) (*http.Transport, error) {
-	proxyURL, err := url.Parse(c.Config.relayURL)
+	proxyURL, err := url.Parse(c.Config.RelayURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing relay URL %w", err)
 	}

--- a/relay.go
+++ b/relay.go
@@ -20,7 +20,7 @@ func (c *Client) relayClient(caCert []byte) (*http.Client, error) {
 }
 
 func (c *Client) transport(caCert []byte) (*http.Transport, error) {
-	proxyURL, err := url.Parse(c.Config.RelayURL)
+	proxyURL, err := url.Parse(c.Config.relayURL)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing relay URL %w", err)
 	}


### PR DESCRIPTION
# Why
Current way to create the client is odd as it requires creation of a Config.

# How
- Refactor with MakeClient and MakeCustomClient, creating an instance of the SDK can now be done with or without a Config.
```
client, err := evervault.MakeClient("EV_API_KEY")

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
