### PR TITLE
Eoin/bugfix not setting api key on post

### DIFF
--- a/client.go
+++ b/client.go
@@ -176,6 +176,8 @@ func (c *Client) buildRequestContext(clientRequest clientRequest) (*http.Request
 		return nil, fmt.Errorf("Error creating request %w", err)
 	}
 
+	setRequestHeaders(req, clientRequest.apiKey, clientRequest.runToken)
+
 	return req, nil
 }
 

--- a/evervault.go
+++ b/evervault.go
@@ -12,7 +12,7 @@ import (
 	"github.com/evervault/evervault-go/internal/datatypes"
 )
 
-const clientVersion = "0.0.1"
+const clientVersion = "0.1.3"
 
 var ClientVersion = clientVersion
 

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -151,6 +152,8 @@ func TestRunFunction(t *testing.T) {
 func startMockHTTPServer(mockResponse []byte) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, reader *http.Request) {
 		if reader.URL.Path == "/test_function" {
+			apiKey := reader.Header.Get("api-key")
+			fmt.Println(apiKey)
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")
 			responseBody := evervault.FunctionRunResponse{

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -128,7 +127,7 @@ func TestGetFunctionRunToken(t *testing.T) {
 	}
 }
 
-func TestRunFunction(t *testing.T) {
+func TestRunFunctionWithRunToken(t *testing.T) {
 	t.Parallel()
 
 	functionResponsePayload := []byte("{\"name\": \"ev:fdfksjdfksjdfjsdfsf\", \"age\": \"ev:dfkjsdfkjsdfjsdfjsdf\"}")
@@ -149,11 +148,35 @@ func TestRunFunction(t *testing.T) {
 	}
 }
 
+func TestRunFunctionWithApiKey(t *testing.T) {
+	t.Parallel()
+
+	functionResponsePayload := []byte("{\"name\": \"ev:fdfksjdfksjdfjsdfsf\", \"age\": \"ev:dfkjsdfkjsdfjsdfjsdf\"}")
+	server := startMockHTTPServer(functionResponsePayload)
+
+	defer server.Close()
+
+	testClient := mockedClient(t, server)
+	payload := map[string]interface{}{
+		"name": "john",
+		"age":  30,
+	}
+
+	res, _ := testClient.RunFunction("test_function", payload, "")
+	if string(res.Result) != string(functionResponsePayload) {
+		t.Errorf("Expected encrypted string, got %s", res)
+	}
+}
+
 func startMockHTTPServer(mockResponse []byte) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, reader *http.Request) {
 		if reader.URL.Path == "/test_function" {
-			apiKey := reader.Header.Get("api-key")
-			fmt.Println(apiKey)
+			apiKey := reader.Header.Get("API-KEY")
+			authHeader := reader.Header.Get("Authorization")
+			if apiKey == "" && authHeader == "" {
+				writer.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")
 			responseBody := evervault.FunctionRunResponse{


### PR DESCRIPTION
# Why
- Evervault HTTP client was not setting the headers for POST requests

# How
- Set headers on post request
- Add tests to check for auth tokens
- Update global client version

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
