### PR TITLE
Eoin/bugfix parse response correctly

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,9 +30,9 @@ type RunTokenResponse struct {
 }
 
 type FunctionRunResponse struct {
-	AppUUID string `json:"appUuid"`
-	RunID   string `json:"runId"`
-	Result  []byte `json:"result"`
+	AppUUID string                 `json:"appUuid"`
+	RunID   string                 `json:"runId"`
+	Result  map[string]interface{} `json:"result"`
 }
 
 type clientRequest struct {

--- a/client.go
+++ b/client.go
@@ -30,9 +30,9 @@ type RunTokenResponse struct {
 }
 
 type FunctionRunResponse struct {
-	AppUUID string                 `json:"appUuid"`
-	RunID   string                 `json:"runId"`
-	Result  map[string]interface{} `json:"result"`
+	AppUUID string         `json:"appUuid"`
+	RunID   string         `json:"runId"`
+	Result  map[string]any `json:"result"`
 }
 
 type clientRequest struct {

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -130,7 +130,14 @@ func TestGetFunctionRunToken(t *testing.T) {
 func TestRunFunctionWithRunToken(t *testing.T) {
 	t.Parallel()
 
-	functionResponsePayload := []byte("{\"name\": \"ev:fdfksjdfksjdfjsdfsf\", \"age\": \"ev:dfkjsdfkjsdfjsdfjsdf\"}")
+	functionResponsePayload := map[string]interface{}{
+		"appUuid": "app_89a080d2228e",
+		"result": map[string]interface{}{
+			"message": "Hello from a Function! It seems you have 4 letters in your name",
+			"name":    "ev:z6CVgEMXL2eqh0io:A4K51eCnhkHkwJ5GiZs9pOGvsWQJv4MBdckQ5rPjm/O7:FgbRc2CYwxuuzFmyh86mTKQ/ah0=:$",
+		},
+		"runId": "func_run_65bc5168cb8b",
+	}
 	server := startMockHTTPServer(functionResponsePayload)
 
 	defer server.Close()
@@ -143,15 +150,21 @@ func TestRunFunctionWithRunToken(t *testing.T) {
 	runToken := "test_token"
 
 	res, _ := testClient.RunFunction("test_function", payload, runToken)
-	if string(res.Result) != string(functionResponsePayload) {
+	if res.AppUUID != functionResponsePayload["appUuid"] {
 		t.Errorf("Expected encrypted string, got %s", res)
 	}
 }
 
 func TestRunFunctionWithApiKey(t *testing.T) {
 	t.Parallel()
-
-	functionResponsePayload := []byte("{\"name\": \"ev:fdfksjdfksjdfjsdfsf\", \"age\": \"ev:dfkjsdfkjsdfjsdfjsdf\"}")
+	functionResponsePayload := map[string]interface{}{
+		"appUuid": "app_89a080d2228e",
+		"result": map[string]interface{}{
+			"message": "Hello from a Function! It seems you have 4 letters in your name",
+			"name":    "ev:z6CVgEMXL2eqh0io:A4K51eCnhkHkwJ5GiZs9pOGvsWQJv4MBdckQ5rPjm/O7:FgbRc2CYwxuuzFmyh86mTKQ/ah0=:$",
+		},
+		"runId": "func_run_65bc5168cb8b",
+	}
 	server := startMockHTTPServer(functionResponsePayload)
 
 	defer server.Close()
@@ -163,12 +176,12 @@ func TestRunFunctionWithApiKey(t *testing.T) {
 	}
 
 	res, _ := testClient.RunFunction("test_function", payload, "")
-	if string(res.Result) != string(functionResponsePayload) {
+	if res.AppUUID != functionResponsePayload["appUuid"] {
 		t.Errorf("Expected encrypted string, got %s", res)
 	}
 }
 
-func startMockHTTPServer(mockResponse []byte) *httptest.Server {
+func startMockHTTPServer(mockResponse map[string]interface{}) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, reader *http.Request) {
 		if reader.URL.Path == "/test_function" {
 			apiKey := reader.Header.Get("API-KEY")
@@ -180,9 +193,9 @@ func startMockHTTPServer(mockResponse []byte) *httptest.Server {
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")
 			responseBody := evervault.FunctionRunResponse{
-				AppUUID: "test_app_uuid",
-				RunID:   "func_jksf93423df",
-				Result:  mockResponse,
+				AppUUID: mockResponse["appUuid"].(string),
+				RunID:   mockResponse["runId"].(string),
+				Result:  mockResponse["result"].(map[string]interface{}),
 			}
 			json.NewEncoder(writer).Encode(responseBody)
 

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -157,6 +157,7 @@ func TestRunFunctionWithRunToken(t *testing.T) {
 
 func TestRunFunctionWithApiKey(t *testing.T) {
 	t.Parallel()
+
 	functionResponsePayload := map[string]interface{}{
 		"appUuid": "app_89a080d2228e",
 		"result": map[string]interface{}{
@@ -165,6 +166,7 @@ func TestRunFunctionWithApiKey(t *testing.T) {
 		},
 		"runId": "func_run_65bc5168cb8b",
 	}
+
 	server := startMockHTTPServer(functionResponsePayload)
 
 	defer server.Close()
@@ -192,10 +194,22 @@ func startMockHTTPServer(mockResponse map[string]interface{}) *httptest.Server {
 			}
 			writer.WriteHeader(http.StatusOK)
 			writer.Header().Set("Content-Type", "application/json")
+			appUUIDResponse, appUUIDOk := mockResponse["appUuid"].(string)
+			if !appUUIDOk {
+				appUUIDResponse = ""
+			}
+			runIDResposne, ok := mockResponse["runId"].(string)
+			if !ok {
+				runIDResposne = ""
+			}
+			resultResponse, ok := mockResponse["result"].(map[string]interface{})
+			if !ok {
+				resultResponse = map[string]interface{}{}
+			}
 			responseBody := evervault.FunctionRunResponse{
-				AppUUID: mockResponse["appUuid"].(string),
-				RunID:   mockResponse["runId"].(string),
-				Result:  mockResponse["result"].(map[string]interface{}),
+				AppUUID: appUUIDResponse,
+				RunID:   runIDResposne,
+				Result:  resultResponse,
 			}
 			json.NewEncoder(writer).Encode(responseBody)
 

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -143,7 +143,7 @@ func TestRunFunctionWithRunToken(t *testing.T) {
 	defer server.Close()
 
 	testClient := mockedClient(t, server)
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"name": "john",
 		"age":  30,
 	}
@@ -160,7 +160,7 @@ func TestRunFunctionWithApiKey(t *testing.T) {
 
 	functionResponsePayload := map[string]interface{}{
 		"appUuid": "app_89a080d2228e",
-		"result": map[string]interface{}{
+		"result": map[string]any{
 			"message": "Hello from a Function! It seems you have 4 letters in your name",
 			"name":    "ev:z6CVgEMXL2eqh0io:A4K51eCnhkHkwJ5GiZs9pOGvsWQJv4MBdckQ5rPjm/O7:FgbRc2CYwxuuzFmyh86mTKQ/ah0=:$",
 		},
@@ -183,7 +183,7 @@ func TestRunFunctionWithApiKey(t *testing.T) {
 	}
 }
 
-func startMockHTTPServer(mockResponse map[string]interface{}) *httptest.Server {
+func startMockHTTPServer(mockResponse map[string]any) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, reader *http.Request) {
 		if reader.URL.Path == "/test_function" {
 			apiKey := reader.Header.Get("API-KEY")
@@ -202,9 +202,9 @@ func startMockHTTPServer(mockResponse map[string]interface{}) *httptest.Server {
 			if !ok {
 				runIDResposne = ""
 			}
-			resultResponse, ok := mockResponse["result"].(map[string]interface{})
+			resultResponse, ok := mockResponse["result"].(map[string]any)
 			if !ok {
-				resultResponse = map[string]interface{}{}
+				resultResponse = map[string]any{}
 			}
 			responseBody := evervault.FunctionRunResponse{
 				AppUUID: appUUIDResponse,

--- a/relay.go
+++ b/relay.go
@@ -34,6 +34,9 @@ func (c *Client) transport(caCert []byte) (*http.Transport, error) {
 		DisableKeepAlives: true,
 		TLSClientConfig:   tlsClientConfig,
 		Proxy:             http.ProxyURL(proxyURL),
+		ProxyConnectHeader: http.Header{
+			"Proxy-Authorization": []string{c.apiKey},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
# Why
- `RunFunctionResponse` failing to parse response from Functions Runtime
- `enableOutboundRelay` not setting `api-key` header for Relay proxy auth

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
