### PR TITLE
feat: make client with an appUUID

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 
 type Client struct {
 	apiKey                    string
+	appUUID                   string
 	Config                    Config
 	p256PublicKeyUncompressed []byte
 	p256PublicKeyCompressed   []byte

--- a/evervault.go
+++ b/evervault.go
@@ -18,20 +18,20 @@ var ClientVersion = clientVersion
 
 var (
 	ErrClientNotInitilization          = errors.New("evervault client unable to initialize")
-	ErrAPIKeyRequired                  = errors.New("evervault client requires an api key")
+	ErrAppCredentialsRequired          = errors.New("evervault client requires an api key and app uuid")
 	ErrCryptoKeyImportError            = errors.New("unable to import crypto key")
 	ErrCryptoUnableToPerformEncryption = errors.New("unable to perform encryption")
 	ErrInvalidDataType                 = errors.New("Error: Invalid datatype")
 )
 
-// MakeClient creates a new Client instance if an API key is provided. The client
+// MakeClient creates a new Client instance if an API key and Evervault App UUID is provided. The client
 // will connect to Evervaults API to retrieve the public keys from your Evervault App.
 //
 // If an apiKey is not passed then ErrAPIKeyRequired is returned. If the client cannot
 // be created then nil will be returned.
-func MakeClient(apiKey string) (*Client, error) {
+func MakeClient(apiKey string, appUUID string) (*Client, error) {
 	config := MakeConfig()
-	return MakeCustomClient(apiKey, config)
+	return MakeCustomClient(apiKey, appUUID, config)
 }
 
 // MakeCustomClient creates a new Client instance but can be specified with a Config. The client
@@ -39,14 +39,15 @@ func MakeClient(apiKey string) (*Client, error) {
 //
 // If an apiKey is not passed then ErrAPIKeyRequired is returned. If the client cannot
 // be created then nil will be returned.
-func MakeCustomClient(apiKey string, config Config) (*Client, error) {
-	if apiKey == "" {
-		return nil, ErrAPIKeyRequired
+func MakeCustomClient(apiKey string, appUUID string, config Config) (*Client, error) {
+	if apiKey == "" || appUUID == "" {
+		return nil, ErrAppCredentialsRequired
 	}
 
 	client := &Client{
-		apiKey: apiKey,
-		Config: config,
+		apiKey:  apiKey,
+		appUUID: appUUID,
+		Config:  config,
 	}
 
 	err := client.initClient()

--- a/evervault.go
+++ b/evervault.go
@@ -27,7 +27,7 @@ var (
 // MakeClient creates a new Client instance if an API key and Evervault App UUID is provided. The client
 // will connect to Evervaults API to retrieve the public keys from your Evervault App.
 //
-// If an apiKey is not passed then ErrAPIKeyRequired is returned. If the client cannot
+// If an apiKey is not passed then ErrAppCredentialsRequired is returned. If the client cannot
 // be created then nil will be returned.
 func MakeClient(apiKey string, appUUID string) (*Client, error) {
 	config := MakeConfig()
@@ -37,7 +37,7 @@ func MakeClient(apiKey string, appUUID string) (*Client, error) {
 // MakeCustomClient creates a new Client instance but can be specified with a Config. The client
 // will connect to Evervaults API to retrieve the public keys from your Evervault App.
 //
-// If an apiKey is not passed then ErrAPIKeyRequired is returned. If the client cannot
+// If an apiKey or appUUID is not passed then ErrAppCredentialsRequired is returned. If the client cannot
 // be created then nil will be returned.
 func MakeCustomClient(apiKey string, appUUID string, config Config) (*Client, error) {
 	if apiKey == "" || appUUID == "" {

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -77,9 +77,14 @@ func TestClientInitClientErrorWithoutApiKey(t *testing.T) {
 	server := startMockHTTPServer(nil)
 	defer server.Close()
 
-	_, err := evervault.MakeClient("")
+	_, err := evervault.MakeClient("", "")
 
-	if err.Error() != evervault.ErrAPIKeyRequired.Error() {
+	if err.Error() != evervault.ErrAppCredentialsRequired.Error() {
+		t.Errorf("Unexpected error, got error message %s", err)
+	}
+
+	_, err = evervault.MakeCustomClient("test_api_key", "", evervault.MakeConfig())
+	if err.Error() != evervault.ErrAppCredentialsRequired.Error() {
 		t.Errorf("Unexpected error, got error message %s", err)
 	}
 }
@@ -253,7 +258,7 @@ func mockedClient(t *testing.T, server *httptest.Server) *evervault.Client {
 		RelayURL:       server.URL,
 	}
 
-	client, err := evervault.MakeCustomClient("test_api_key", config)
+	client, err := evervault.MakeCustomClient("test_api_key", "test_app_uuid", config)
 	if err != nil {
 		t.Fail()
 	}


### PR DESCRIPTION
# Why
Going forward the App's UUID will be required for using the decrypt API

# How
- Add appUUID as a required parameter for the make client function.

# Checklist

- [X] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
