### PR TITLE
feat(tokens): adds support for tokens create to the sdk

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-
-	"github.com/evervault/evervault-go/internal/datatypes"
 )
 
 // Evervault Client.
@@ -44,6 +42,11 @@ type clientRequest struct {
 	appUUID  string
 	apiKey   string
 	runToken string
+}
+
+type TokenResponse struct {
+	Token  string `json:"token"`
+	Expiry int64 `json:"expiry"`
 }
 
 func (c *Client) initClient() error {
@@ -106,7 +109,7 @@ func (c *Client) decrypt(encryptedData any) (map[string]any, error) {
 	return res, nil
 }
 
-func (c *Client) createToken(action string, payload any, expiry int64) (datatypes.TokenResponse, error) {
+func (c *Client) createToken(action string, payload any, expiry int64) (TokenResponse, error) {
 	body := map[string]any{
 		"action": action,
 		"payload": payload,
@@ -115,19 +118,19 @@ func (c *Client) createToken(action string, payload any, expiry int64) (datatype
 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
-		return datatypes.TokenResponse{}, fmt.Errorf("Error marshalling payload to json %w", err)
+		return TokenResponse{}, fmt.Errorf("Error marshalling payload to json %w", err)
 	}
 
 	tokenURL := fmt.Sprintf("%s/execution-token", c.Config.EvAPIURL)
 
 	tokenResult, err := c.makeRequest(tokenURL, "POST", bodyBytes, "")
 	if err != nil {
-		return datatypes.TokenResponse{}, err
+		return TokenResponse{}, err
 	}
 
-	res := datatypes.TokenResponse{}
+	res := TokenResponse{}
 	if err := json.Unmarshal(tokenResult, &res); err != nil {
-		return datatypes.TokenResponse{}, fmt.Errorf("Error parsing JSON response %w", err)
+		return TokenResponse{}, fmt.Errorf("Error parsing JSON response %w", err)
 	}
 
 	return res, nil

--- a/client.go
+++ b/client.go
@@ -121,7 +121,7 @@ func (c *Client) createToken(action string, payload any, expiry int64) (TokenRes
 		return TokenResponse{}, fmt.Errorf("Error marshalling payload to json %w", err)
 	}
 
-	tokenURL := fmt.Sprintf("%s/execution-token", c.Config.EvAPIURL)
+	tokenURL := fmt.Sprintf("%s/client-side-tokens", c.Config.EvAPIURL)
 
 	tokenResult, err := c.makeRequest(tokenURL, "POST", bodyBytes, "")
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -104,6 +104,33 @@ func (c *Client) decrypt(encryptedData any) (map[string]any, error) {
 	return res, nil
 }
 
+func (c *Client) createToken(action string, payload, expiry any) (map[string]any, error) {
+	body := map[string]any{
+		"action": action,
+		"payload": payload,
+		"expiry": expiry,
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("Error marshalling payload to json %w", err)
+	}
+
+	tokenURL := fmt.Sprintf("%s/execution-token", c.Config.EvAPIURL)
+
+	tokenResult, err := c.makeRequest(tokenURL, "POST", bodyBytes, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string]any
+	if err := json.Unmarshal(tokenResult, &res); err != nil {
+		return nil, fmt.Errorf("Error parsing JSON response %w", err)
+	}
+
+	return res, nil
+}
+
 func (c *Client) makeRequest(url, method string, body []byte, runToken string) ([]byte, error) {
 	req, err := c.buildRequestContext(clientRequest{
 		url:      url,

--- a/client.go
+++ b/client.go
@@ -106,7 +106,7 @@ func (c *Client) decrypt(encryptedData any) (map[string]any, error) {
 	return res, nil
 }
 
-func (c *Client) createToken(action string, payload, expiry any) (datatypes.TokenResponse, error) {
+func (c *Client) createToken(action string, payload any, expiry int64) (datatypes.TokenResponse, error) {
 	body := map[string]any{
 		"action": action,
 		"payload": payload,

--- a/client.go
+++ b/client.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/evervault/evervault-go/internal/datatypes"
 )
 
 // Evervault Client.
@@ -104,7 +106,7 @@ func (c *Client) decrypt(encryptedData any) (map[string]any, error) {
 	return res, nil
 }
 
-func (c *Client) createToken(action string, payload, expiry any) (map[string]any, error) {
+func (c *Client) createToken(action string, payload, expiry any) (datatypes.TokenResponse, error) {
 	body := map[string]any{
 		"action": action,
 		"payload": payload,
@@ -113,19 +115,19 @@ func (c *Client) createToken(action string, payload, expiry any) (map[string]any
 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshalling payload to json %w", err)
+		return datatypes.TokenResponse{}, fmt.Errorf("Error marshalling payload to json %w", err)
 	}
 
 	tokenURL := fmt.Sprintf("%s/execution-token", c.Config.EvAPIURL)
 
 	tokenResult, err := c.makeRequest(tokenURL, "POST", bodyBytes, "")
 	if err != nil {
-		return nil, err
+		return datatypes.TokenResponse{}, err
 	}
 
-	var res map[string]any
+	res := datatypes.TokenResponse{}
 	if err := json.Unmarshal(tokenResult, &res); err != nil {
-		return nil, fmt.Errorf("Error parsing JSON response %w", err)
+		return datatypes.TokenResponse{}, fmt.Errorf("Error parsing JSON response %w", err)
 	}
 
 	return res, nil

--- a/evervault.go
+++ b/evervault.go
@@ -146,6 +146,7 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 func (c *Client) CreateClientSideDecryptToken(payload any, expiry time.Time) (TokenResponse, error) {
 	epochTime := expiry.UnixMilli()
 	token, err := c.createToken("decrypt:api", payload, epochTime)
+
 	if err != nil {
 		return TokenResponse{}, err
 	}

--- a/evervault.go
+++ b/evervault.go
@@ -152,7 +152,7 @@ func (c *Client) CreateClientSideDecryptToken(payload any, expiry ...time.Time) 
 		epochTime = expiry[0].UnixMilli()
 	}
 
-	token, err := c.createToken("decrypt:api", payload, epochTime)
+	token, err := c.createToken("api:decrypt", payload, epochTime)
 
 	if err != nil {
 		return TokenResponse{}, err

--- a/evervault.go
+++ b/evervault.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Current version of the evervault SDK.
-const ClientVersion = "0.3.0"
+const ClientVersion = "0.4.0"
 
 // MakeClient creates a new Client instance if an API key and Evervault App ID is provided. The client
 // will connect to Evervaults API to retrieve the public keys from your Evervault App.
@@ -129,4 +129,13 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 	}
 
 	return decryptResponse, nil
+}
+
+func (c *Client) CreateClientSideDecryptToken(payload, expiry any) (map[string]any, error) {
+	token, err := c.createToken("decrypt:api", payload, expiry)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
 }

--- a/evervault.go
+++ b/evervault.go
@@ -143,8 +143,12 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 // It returns a TokenResponse or an error
 //
 // token, err := CreateClientSideDecryptToken(payload, timeInFiveMinutes)
-func (c *Client) CreateClientSideDecryptToken(payload any, expiry time.Time) (TokenResponse, error) {
-	epochTime := expiry.UnixMilli()
+func (c *Client) CreateClientSideDecryptToken(payload any, expiry ...time.Time) (TokenResponse, error) {
+	var epochTime int64
+	if expiry != nil {
+		epochTime = expiry[0].UnixMilli()
+	}
+
 	token, err := c.createToken("decrypt:api", payload, epochTime)
 
 	if err != nil {

--- a/evervault.go
+++ b/evervault.go
@@ -144,6 +144,11 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 //
 // token, err := CreateClientSideDecryptToken(payload, timeInFiveMinutes)
 func (c *Client) CreateClientSideDecryptToken(payload any, expiry ...time.Time) (TokenResponse, error) {
+	// Used to check whether payload is the zero value for its type
+	if payload == nil {
+		return TokenResponse{}, ErrInvalidDataType
+	}
+
 	var epochTime int64
 	if expiry != nil {
 		epochTime = expiry[0].UnixMilli()

--- a/evervault.go
+++ b/evervault.go
@@ -133,6 +133,13 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 }
 
 // CreateClientSideDecryptToken creates a time bound token that can be used to perform decrypts. 
+// The payload is optional and is the encrypted data you want to decrypt.
+// If passed, only this payload will be able to be decrypted with the token.
+// Othwerise, any encrypted data can be decrypted with the token.
+// 
+// The expiry is the time the token should expire.
+// The max time is 10 minutes in the future and defaults to 5 minutes if not provided
+// 
 // It returns a TokenResponse or an error
 //
 // token, err := CreateClientSideDecryptToken(payload, timeInFiveMinutes)

--- a/evervault.go
+++ b/evervault.go
@@ -133,12 +133,10 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 }
 
 // CreateClientSideDecryptToken creates a time bound token that can be used to perform decrypts. 
-// The payload is optional and is the encrypted data you want to decrypt.
-// If passed, only this payload will be able to be decrypted with the token.
-// Othwerise, any encrypted data can be decrypted with the token.
+// The payload is required and ensures the token can only be used to decrypt that specific payload.
 // 
 // The expiry is the time the token should expire.
-// The max time is 10 minutes in the future and defaults to 5 minutes if not provided
+// The max time is 10 minutes in the future and defaults to 5 minutes if not provided.
 // 
 // It returns a TokenResponse or an error
 //

--- a/evervault.go
+++ b/evervault.go
@@ -132,11 +132,11 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 	return decryptResponse, nil
 }
 
-func (c *Client) CreateClientSideDecryptToken(payload any, expiry time.Time) (datatypes.TokenResponse, error) {
+func (c *Client) CreateClientSideDecryptToken(payload any, expiry time.Time) (TokenResponse, error) {
 	epochTime := expiry.UnixMilli()
 	token, err := c.createToken("decrypt:api", payload, epochTime)
 	if err != nil {
-		return datatypes.TokenResponse{}, err
+		return TokenResponse{}, err
 	}
 
 	return token, nil

--- a/evervault.go
+++ b/evervault.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"time"
 
 	"github.com/evervault/evervault-go/internal/crypto"
 	"github.com/evervault/evervault-go/internal/datatypes"
@@ -131,8 +132,9 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 	return decryptResponse, nil
 }
 
-func (c *Client) CreateClientSideDecryptToken(payload, expiry any) (datatypes.TokenResponse, error) {
-	token, err := c.createToken("decrypt:api", payload, expiry)
+func (c *Client) CreateClientSideDecryptToken(payload any, expiry time.Time) (datatypes.TokenResponse, error) {
+	epochTime := expiry.UnixMilli()
+	token, err := c.createToken("decrypt:api", payload, epochTime)
 	if err != nil {
 		return datatypes.TokenResponse{}, err
 	}

--- a/evervault.go
+++ b/evervault.go
@@ -132,6 +132,10 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 	return decryptResponse, nil
 }
 
+// CreateClientSideDecryptToken creates a time bound token that can be used to perform decrypts. 
+// It returns a TokenResponse or an error
+//
+// token, err := CreateClientSideDecryptToken(payload, timeInFiveMinutes)
 func (c *Client) CreateClientSideDecryptToken(payload any, expiry time.Time) (TokenResponse, error) {
 	epochTime := expiry.UnixMilli()
 	token, err := c.createToken("decrypt:api", payload, epochTime)

--- a/evervault.go
+++ b/evervault.go
@@ -131,10 +131,10 @@ func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
 	return decryptResponse, nil
 }
 
-func (c *Client) CreateClientSideDecryptToken(payload, expiry any) (map[string]any, error) {
+func (c *Client) CreateClientSideDecryptToken(payload, expiry any) (datatypes.TokenResponse, error) {
 	token, err := c.createToken("decrypt:api", payload, expiry)
 	if err != nil {
-		return nil, err
+		return datatypes.TokenResponse{}, err
 	}
 
 	return token, nil

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -77,12 +77,12 @@ func TestCreateClientSideDecryptToken(t *testing.T) {
 		return
 	}
 	
-	if res["token"] != "abcdefghij1234567890" {
-		t.Errorf("Expected token, got %s", res["token"])
+	if res.Token != "abcdefghij1234567890" {
+		t.Errorf("Expected token, got %s", res.Token)
 	}
 
-	if res["expiry"] != expiry {
-		t.Errorf("Expected expiry, got %s", res["expiry"])
+	if res.Expiry != expiry {
+		t.Errorf("Expected expiry, got %s", res.Expiry)
 	}
 }
 

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -246,7 +246,7 @@ func handleRoute(writer http.ResponseWriter, reader *http.Request, mockResponse 
 		}
 	}
 
-	if reader.URL.Path == "/execution-token" {
+	if reader.URL.Path == "/client-side-tokens" {
 		writer.WriteHeader(http.StatusOK)
 		writer.Header().Set("Content-Type", "application/json")
 
@@ -273,7 +273,7 @@ func hasSpecialPath(path string) bool {
 		"/test_function": true,
 		"/v2/functions/test_function/run-token": true,
 		"/decrypt": true,
-		"/execution-token": true,
+		"/client-side-tokens": true,
 	}
 	if specialPaths[path] {
 		return true

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -218,7 +218,7 @@ func testFuncHandler(writer http.ResponseWriter, reader *http.Request, mockRespo
 	}
 }
 
-func startMockHTTPServer(mockResponse map[string]any) *httptest.Server {
+func startMockHTTPServer(mockResponse map[string]any) *httptest.Server { //nolint:all
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, reader *http.Request) {
 		if reader.URL.Path == "/test_function" {
 			testFuncHandler(writer, reader, mockResponse)

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -226,6 +226,7 @@ func handleRoute(writer http.ResponseWriter, reader *http.Request, mockResponse 
 	if reader.URL.Path == "/v2/functions/test_function/run-token" {
 		writer.WriteHeader(http.StatusOK)
 		writer.Header().Set("Content-Type", "application/json")
+
 		if err := json.NewEncoder(writer).Encode(evervault.RunTokenResponse{Token: "test_token"}); err != nil {
 			log.Printf("error encoding json: %s", err)
 		}
@@ -275,6 +276,7 @@ func hasSpecialPath(path string) bool {
 		"/decrypt": true,
 		"/client-side-tokens": true,
 	}
+
 	return specialPaths[path]
 }
 
@@ -282,6 +284,7 @@ func startMockHTTPServer(mockResponse map[string]any) *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, reader *http.Request) {
 		if hasSpecialPath(reader.URL.Path) {
 			handleRoute(writer, reader, mockResponse)
+
 			return
 		}
 

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -275,10 +275,7 @@ func hasSpecialPath(path string) bool {
 		"/decrypt": true,
 		"/client-side-tokens": true,
 	}
-	if specialPaths[path] {
-		return true
-	}
-	return false
+	return specialPaths[path]
 }
 
 func startMockHTTPServer(mockResponse map[string]any) *httptest.Server {

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -69,7 +69,7 @@ func TestCreateClientSideDecryptToken(t *testing.T) {
 		expiry string
 	}
 
-	expiry := time.Now().Format(time.RFC3339)
+	expiry := time.Now()
 	res, err := testClient.CreateClientSideDecryptToken(EncryptedCardData{"4242", "111", "01/23"}, expiry)
 
 	if err != nil {
@@ -81,8 +81,8 @@ func TestCreateClientSideDecryptToken(t *testing.T) {
 		t.Errorf("Expected token, got %s", res.Token)
 	}
 
-	if res.Expiry != expiry {
-		t.Errorf("Expected expiry, got %s", res.Expiry)
+	if res.Expiry != expiry.UnixMilli() {
+		t.Errorf("Expected expiry, got %d", res.Expiry)
 	}
 }
 

--- a/internal/datatypes/datatypes.go
+++ b/internal/datatypes/datatypes.go
@@ -8,3 +8,8 @@ const (
 	Boolean
 	Bytes
 )
+
+type TokenResponse struct {
+	Token  string `json:"token"`
+	Expiry string `json:"expiry"`
+}

--- a/internal/datatypes/datatypes.go
+++ b/internal/datatypes/datatypes.go
@@ -8,8 +8,3 @@ const (
 	Boolean
 	Bytes
 )
-
-type TokenResponse struct {
-	Token  string `json:"token"`
-	Expiry int64 `json:"expiry"`
-}

--- a/internal/datatypes/datatypes.go
+++ b/internal/datatypes/datatypes.go
@@ -11,5 +11,5 @@ const (
 
 type TokenResponse struct {
 	Token  string `json:"token"`
-	Expiry string `json:"expiry"`
+	Expiry int64 `json:"expiry"`
 }


### PR DESCRIPTION
# Why

Need to support the creation of tokens in the Go SDK

# How

- Add `CreateClientSideDecryptToken()` function

# Checklist

- [x] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
