### PR TITLE
chore(e2e_tests): Add e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,4 +26,5 @@ jobs:
         env:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
+          EV_FUNCTION_NAME: ${{ secrets.EV_FUNCTION_NAME }}
         run: go test -v -count=1 -race --tags=e2e ./...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,6 @@
 ---
-name: Test SDK
+name: Run Go SDK E2E Tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 permissions:
@@ -25,13 +22,8 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
           cache: false
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
-          args: --timeout=5m
       - name: Test
         env:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
-        run: go test -v -count=1 -race $(go list ./... | grep -v /e2e) # Exclude e2e tests 
+        run: go test -v -count=1 -race ./e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
-        run: go test -v -count=1 -race ./e2e
+        run: go test -v -count=1 -race --tags=e2e ./...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,4 +27,5 @@ jobs:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
           EV_FUNCTION_NAME: ${{ secrets.EV_FUNCTION_NAME }}
+          EV_SYNTHETIC_ENDPOINT_URL: ${{ secrets.EV_SYNTHETIC_ENDPOINT_URL }}
         run: go test -v -count=1 -race --tags=e2e ./...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,9 +12,9 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.20', '1.21']
         os: [ubuntu-latest, macos-latest, windows-latest]
-    name: lint
+    name: E2E
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
-        run: go test -v -count=1 -race $(go list ./... | grep -v /e2e) # Exclude e2e tests 
+        run: go test -v -count=1 -race --tags=unit_test ./... 

--- a/cage_test.go
+++ b/cage_test.go
@@ -1,3 +1,5 @@
+//+build unit_test
+
 package evervault_test
 
 import (

--- a/client.go
+++ b/client.go
@@ -88,7 +88,7 @@ func (c *Client) getPublicKey() (KeysResponse, error) {
 	return res, nil
 }
 
-func (c *Client) decrypt(encryptedData any) (map[string]any, error) {
+func (c *Client) decrypt(encryptedData any) (any, error) {
 	pBytes, err := json.Marshal(encryptedData)
 	if err != nil {
 		return nil, fmt.Errorf("Error marshalling payload to json %w", err)
@@ -101,7 +101,7 @@ func (c *Client) decrypt(encryptedData any) (map[string]any, error) {
 		return nil, err
 	}
 
-	var res map[string]any
+	var res any
 	if err := json.Unmarshal(decryptedData, &res); err != nil {
 		return nil, fmt.Errorf("Error parsing JSON response %w", err)
 	}
@@ -207,7 +207,7 @@ func setRequestHeaders(req *http.Request, appUUID, apiKey, url, runToken string)
 			stringBytes := []byte(fmt.Sprintf("%s:%s", appUUID, apiKey))
 			base64EncodedHeaderValue := base64.StdEncoding.EncodeToString(stringBytes)
 			req.Header = http.Header{
-				"Authorization": {fmt.Sprintf("Bearer %s", base64EncodedHeaderValue)},
+				"Authorization": {fmt.Sprintf("Basic %s", base64EncodedHeaderValue)},
 				"Content-Type":  {"application/json"},
 				"user-agent":    {fmt.Sprintf("evervault-go/%s", ClientVersion)},
 			}

--- a/client.go
+++ b/client.go
@@ -46,7 +46,7 @@ type clientRequest struct {
 
 type TokenResponse struct {
 	Token  string `json:"token"`
-	Expiry int64 `json:"expiry"`
+	Expiry int64  `json:"expiry"`
 }
 
 func (c *Client) initClient() error {
@@ -111,9 +111,9 @@ func (c *Client) decrypt(encryptedData any) (any, error) {
 
 func (c *Client) createToken(action string, payload any, expiry int64) (TokenResponse, error) {
 	body := map[string]any{
-		"action": action,
+		"action":  action,
 		"payload": payload,
-		"expiry": expiry,
+		"expiry":  expiry,
 	}
 
 	bodyBytes, err := json.Marshal(body)

--- a/e2e/encrypt_e2e_test.go
+++ b/e2e/encrypt_e2e_test.go
@@ -1,4 +1,6 @@
-package e2e_test
+//+build e2e
+
+package encrypt_e2e_test
 
 import (
 	"bytes"
@@ -9,7 +11,7 @@ import (
 	"github.com/evervault/evervault-go"
 )
 
-func TestEncryptString(t *testing.T) {
+func TestE2EEncryptString(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
@@ -40,7 +42,7 @@ func TestEncryptString(t *testing.T) {
 	}
 }
 
-func TestEncryptBoolTrue(t *testing.T) {
+func TestE2EEncryptBoolTrue(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
@@ -65,7 +67,7 @@ func TestEncryptBoolTrue(t *testing.T) {
 	}
 }
 
-func TestEncryptBoolFalse(t *testing.T) {
+func TestE2EEncryptBoolFalse(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
@@ -90,7 +92,7 @@ func TestEncryptBoolFalse(t *testing.T) {
 	}
 }
 
-func TestEncryptInt(t *testing.T) {
+func TestE2EEncryptInt(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
@@ -116,7 +118,7 @@ func TestEncryptInt(t *testing.T) {
 	}
 }
 
-func TestEncryptFloat(t *testing.T) {
+func TestE2EEncryptFloat(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
@@ -141,7 +143,7 @@ func TestEncryptFloat(t *testing.T) {
 	}
 }
 
-func TestEncryptBytes(t *testing.T) {
+func TestE2EEncryptBytes(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
@@ -180,7 +182,7 @@ type MyStruct struct {
 	False  bool    `json:"false"`
 }
 
-func TestEncryptStruct(t *testing.T) {
+func TestE2EEncryptStruct(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)

--- a/e2e/encrypt_e2e_test.go
+++ b/e2e/encrypt_e2e_test.go
@@ -1,6 +1,6 @@
 //+build e2e
 
-package encrypt_e2e_test
+package e2e_test
 
 import (
 	"bytes"

--- a/e2e/encrypt_test.go
+++ b/e2e/encrypt_test.go
@@ -1,0 +1,228 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/evervault/evervault-go"
+)
+
+func TestEncryptString(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := "hello world"
+	encrypted, err := client.Encrypt(payload)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.Decrypt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted.(string) {
+		t.Errorf("decrypted data does not match the original")
+		return
+	}
+}
+
+func TestEncryptBoolTrue(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := true
+	encrypted, err := client.Encrypt(payload)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.Decrypt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original")
+		return
+	}
+}
+
+func TestEncryptBoolFalse(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := false
+	encrypted, err := client.Encrypt(payload)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.Decrypt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original")
+		return
+	}
+}
+
+func TestEncryptInt(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := 1
+	encrypted, err := client.Encrypt(payload)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.Decrypt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	// Need to convert here, as ints are returned as floats
+	if float64(payload) != decrypted {
+		t.Errorf("decrypted data does not match the original")
+		return
+	}
+}
+
+func TestEncryptFloat(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := 1.5
+	encrypted, err := client.Encrypt(payload)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.Decrypt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original")
+		return
+	}
+}
+
+func TestEncryptBytes(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := []byte{97, 98, 99, 100, 101, 102}
+	encrypted, err := client.Encrypt(payload)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.Decrypt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if string(payload) != decrypted.(string) {
+		t.Errorf("decrypted data does not match the original")
+		return
+	}
+}
+
+type MyStruct struct {
+	String string  `json:"string"`
+	Int    int     `json:"int"`
+	Float  float64 `json:"float"`
+	True   bool    `json:"true"`
+	False  bool    `json:"false"`
+}
+
+func TestEncryptStruct(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := MyStruct{"hello world", 1, 1.5, true, false}
+
+	// Encrypt doesn't handle structs - convert to bytes first
+	reqBodyBytes := new(bytes.Buffer)
+	json.NewEncoder(reqBodyBytes).Encode(payload)
+
+	encrypted, err := client.Encrypt(reqBodyBytes.Bytes())
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.Decrypt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	// Convert bytes back to struct
+	data := MyStruct{}
+    json.Unmarshal([]byte(decrypted.(string)), &data)
+
+	if payload.String != data.String {
+		t.Errorf("decrypted struct data `String` does not match the original")
+		return
+	}
+
+	if payload.Int != data.Int {
+		t.Errorf("decrypted struct data `Int` does not match the original")
+		return
+	}
+
+	if payload.Float != data.Float {
+		t.Errorf("decrypted struct data `Float` does not match the original")
+		return
+	}
+
+	if payload.True != data.True {
+		t.Errorf("decrypted struct data `True` does not match the original")
+		return
+	}
+
+	if payload.False != data.False {
+		t.Errorf("decrypted struct data `False` does not match the original")
+		return
+	}
+}
+
+func GetClient(t *testing.T) *evervault.Client {
+	appUuid := os.Getenv("EV_APP_UUID")
+	apiKey := os.Getenv("EV_API_KEY")
+
+	client, err := evervault.MakeClient(appUuid, apiKey)
+	if err != nil {
+		t.Fail()
+	}
+
+	return client
+}

--- a/e2e/function_e2e_test.go
+++ b/e2e/function_e2e_test.go
@@ -1,0 +1,74 @@
+//+build e2e
+
+package e2e_test
+
+import (
+	"os"
+	"testing"
+)
+
+var functionName string = os.Getenv("EV_FUNCTION_NAME")
+
+type MyData struct {
+	Name string `json:"name"`
+	Age int `json:"age"`
+	IsAlive bool `json:"isAlive"`
+}
+
+type payload struct {
+	Name string `json:"name"`
+	Age string `json:"age"`
+	IsAlive string `json:"isAlive"`
+}
+
+func TestE2EFunctionRunWithToken(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	data := MyData{"John Doe", 42, true}
+
+	encrypted, err := client.Encrypt(data.Name)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	payload := payload{}
+
+	payload.Name = encrypted
+
+	encrypted, err = client.Encrypt(data.Age)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	payload.Age = encrypted
+
+	encrypted, err = client.Encrypt(data.IsAlive)
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	payload.IsAlive = encrypted
+
+	token, err := client.CreateFunctionRunToken(functionName, data)
+	if err != nil {
+		t.Errorf("error creating token %s", err)
+		return
+	}
+
+	runResult, err := client.RunFunction(functionName, data, token.Token)
+	if err != nil {
+		t.Errorf("error running function %s", err)
+		return
+	}
+
+	if runResult.Result["message"] != "OK" {
+		t.Errorf("Unexpected function run response %s", runResult.Result["message"])
+		return
+	}
+
+}

--- a/e2e/outbound_e2e_test.go
+++ b/e2e/outbound_e2e_test.go
@@ -1,0 +1,84 @@
+//+build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var syntheticEndpointUrl string = os.Getenv("EV_SYNTHETIC_ENDPOINT_URL")
+
+func TestE2EOutboundRelay(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	encryptedString, err := client.Encrypt("some_string")
+	if err != nil {
+		t.Errorf("error encrypting string %s", err)
+		return
+	}
+
+	encryptedNumber, err := client.Encrypt(1234567890)
+	if err != nil {
+		t.Errorf("error encrypting number %s", err)
+		return
+	}
+	
+	encryptedBool, err := client.Encrypt(true)
+	if err != nil {
+		t.Errorf("error encrypting bool %s", err)
+		return
+	}
+
+	outboundRelayClient, err := client.OutboundRelayClient()
+    if err != nil {
+		t.Errorf("Error getting outbound client %s", err)
+		return
+    }
+
+	data := map[string]string{"string": encryptedString, "number": encryptedNumber, "boolean": encryptedBool}
+    payload, err := json.Marshal(data)
+    if err != nil {
+        t.Errorf("error Marshalling payload %s", err)
+		return
+    }
+
+    resp, err := outboundRelayClient.Post(syntheticEndpointUrl, "application/json", bytes.NewReader(payload))
+    if err != nil {
+        t.Errorf("error posting with outbound client %s", err)
+		return
+    }
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("error posting with outbound client %s", err)
+		return
+	}
+
+	// close response body
+	resp.Body.Close()
+
+	responseData := make(map[string]map[string]bool)
+
+	json.Unmarshal(body, &responseData)
+
+	if responseData["request"]["string"] != false {
+		t.Errorf("Expected false as response %t", responseData["request"]["string"])
+		return
+	}
+
+	if responseData["request"]["number"] != false {
+		t.Errorf("Expected false as response %t", responseData["request"]["number"])
+		return
+	}
+
+	if responseData["request"]["boolean"] != false {
+		t.Errorf("Expected false as response %t", responseData["request"]["boolean"])
+		return
+	}
+}

--- a/evervault.go
+++ b/evervault.go
@@ -118,7 +118,7 @@ func (c *Client) encryptValue(value any, aesKey, ephemeralPublicKey []byte) (str
 // Decrypt decrypts data previously encrypted with Encrypt or through Relay
 //
 //	decrypted := evClient.Decrypt(encrypted);
-func (c *Client) Decrypt(encryptedData any) (map[string]any, error) {
+func (c *Client) Decrypt(encryptedData any) (any, error) {
 	// Used to check whether encryptedData is the zero value for its type
 	if reflect.ValueOf(encryptedData).IsZero() {
 		return nil, ErrInvalidDataType

--- a/evervault.go
+++ b/evervault.go
@@ -132,15 +132,15 @@ func (c *Client) Decrypt(encryptedData any) (any, error) {
 	return decryptResponse, nil
 }
 
-// CreateClientSideDecryptToken creates a time bound token that can be used to perform decrypts. 
+// CreateClientSideDecryptToken creates a time bound token that can be used to perform decrypts.
 // The payload is required and ensures the token can only be used to decrypt that specific payload.
-// 
+//
 // The expiry is the time the token should expire.
 // The max time is 10 minutes in the future and defaults to 5 minutes if not provided.
-// 
-// It returns a TokenResponse or an error
 //
-// token, err := CreateClientSideDecryptToken(payload, timeInFiveMinutes)
+// # It returns a TokenResponse or an error
+//
+// token, err := CreateClientSideDecryptToken(payload, timeInFiveMinutes).
 func (c *Client) CreateClientSideDecryptToken(payload any, expiry ...time.Time) (TokenResponse, error) {
 	// Used to check whether payload is the zero value for its type
 	if payload == nil {
@@ -153,7 +153,6 @@ func (c *Client) CreateClientSideDecryptToken(payload any, expiry ...time.Time) 
 	}
 
 	token, err := c.createToken("api:decrypt", payload, epochTime)
-
 	if err != nil {
 		return TokenResponse{}, err
 	}

--- a/evervault.go
+++ b/evervault.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Current version of the evervault SDK.
-const ClientVersion = "0.4.0"
+const ClientVersion = "0.4.1"
 
 // MakeClient creates a new Client instance if an API key and Evervault App ID is provided. The client
 // will connect to Evervaults API to retrieve the public keys from your Evervault App.

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -42,7 +42,10 @@ func TestDecrypt(t *testing.T) {
 		return
 	}
 
-	castResponse := res.(map[string]any)
+	castResponse, ok := res.(map[string]any)
+	if !ok {
+		t.Errorf("Expected to cast response to map correctly")
+	}
 
 	if reflect.TypeOf(castResponse["number"]) != stringType {
 		t.Errorf("Expected encrypted string, got %s", castResponse["number"])
@@ -67,18 +70,18 @@ func TestCreateClientSideDecryptToken(t *testing.T) {
 
 	type EncryptedCardData struct {
 		number string
-		cvv string
+		cvv    string
 		expiry string
 	}
 
 	expiry := time.Now()
-	res, err := testClient.CreateClientSideDecryptToken(EncryptedCardData{"4242", "111", "01/23"}, expiry)
 
+	res, err := testClient.CreateClientSideDecryptToken(EncryptedCardData{"4242", "111", "01/23"}, expiry)
 	if err != nil {
 		t.Errorf("error creating decrypt token %s", err)
 		return
 	}
-	
+
 	if res.Token != "abcdefghij1234567890" {
 		t.Errorf("Expected token, got %s", res.Token)
 	}
@@ -254,14 +257,14 @@ func handleRoute(writer http.ResponseWriter, reader *http.Request, mockResponse 
 		writer.Header().Set("Content-Type", "application/json")
 
 		var body map[string]any
-		err := json.NewDecoder(reader.Body).Decode(&body)
 
+		err := json.NewDecoder(reader.Body).Decode(&body)
 		if err != nil {
 			log.Printf("error decoding body: %s", err)
 		}
 
 		returnData := map[string]interface{}{
-			"token": "abcdefghij1234567890",
+			"token":  "abcdefghij1234567890",
 			"expiry": body["expiry"],
 		}
 
@@ -272,11 +275,11 @@ func handleRoute(writer http.ResponseWriter, reader *http.Request, mockResponse 
 }
 
 func hasSpecialPath(path string) bool {
-	specialPaths := map[string]bool {
-		"/test_function": true,
+	specialPaths := map[string]bool{
+		"/test_function":                        true,
 		"/v2/functions/test_function/run-token": true,
-		"/decrypt": true,
-		"/client-side-tokens": true,
+		"/decrypt":                              true,
+		"/client-side-tokens":                   true,
 	}
 
 	return specialPaths[path]

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -1,3 +1,5 @@
+//+build unit_test
+
 package evervault_test
 
 import (

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -42,16 +42,18 @@ func TestDecrypt(t *testing.T) {
 		return
 	}
 
-	if reflect.TypeOf(res["number"]) != stringType {
-		t.Errorf("Expected encrypted string, got %s", res["number"])
+	castResponse := res.(map[string]any)
+
+	if reflect.TypeOf(castResponse["number"]) != stringType {
+		t.Errorf("Expected encrypted string, got %s", castResponse["number"])
 	}
 
-	if reflect.TypeOf(res["cvv"]) != floatType {
-		t.Errorf("Expected encrypted string, got %s", res["cvv"])
+	if reflect.TypeOf(castResponse["cvv"]) != floatType {
+		t.Errorf("Expected encrypted string, got %s", castResponse["cvv"])
 	}
 
-	if reflect.TypeOf(res["expiry"]) != stringType {
-		t.Errorf("Expected encrypted string, got %s", res["expiry"])
+	if reflect.TypeOf(castResponse["expiry"]) != stringType {
+		t.Errorf("Expected encrypted string, got %s", castResponse["expiry"])
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,3 +1,5 @@
+//+build unit_test
+
 package evervault_test
 
 import (

--- a/function_test.go
+++ b/function_test.go
@@ -1,3 +1,5 @@
+//+build unit_test
+
 package evervault_test
 
 import "testing"

--- a/relay_test.go
+++ b/relay_test.go
@@ -1,3 +1,5 @@
+//+build unit_test
+
 package evervault_test
 
 import (


### PR DESCRIPTION
# Why

Developing the Go SDK required a lot of manual testing. Automated end-to-end tests were highly needed.

# How

This PR introduces the following changes:

- Add e2e tests to validate encryption & decryption
- Add github workflow to automatically trigger e2e tests when pushing a change
- Make handling of arbitrary types with `Decrypt` smoother

# Checklist

- [ ] Commit messages are formatted as per [the convention](https://www.conventionalcommits.org/en/v1.0.0/), and breaking changes are marked
