### PR TITLE
Embedding data roles

### DIFF
--- a/.changeset/great-drinks-rush.md
+++ b/.changeset/great-drinks-rush.md
@@ -1,0 +1,7 @@
+---
+"evervault-go": minor
+---
+
+The `Encrypt` functions have been enhanced to accept an optional Data Role. This role, where specified, is associated with the data upon encryption. Data Roles can be created in the Evervault Dashboard (Data Roles section) and provide a mechanism for setting rules that dictate how and when data, tagged with that role, can be decrypted.
+
+evervault.EncryptString("hello world!", "allow-all");

--- a/.changeset/great-drinks-rush.md
+++ b/.changeset/great-drinks-rush.md
@@ -2,6 +2,8 @@
 "evervault-go": minor
 ---
 
-The `Encrypt` functions have been enhanced to accept an optional Data Role. This role, where specified, is associated with the data upon encryption. Data Roles can be created in the Evervault Dashboard (Data Roles section) and provide a mechanism for setting rules that dictate how and when data, tagged with that role, can be decrypted.
+The `Encrypt` functions have been enhanced to accept an optional Data Role.
+
+This role, once specified, is associated with the data upon encryption. Data Roles can be created in the Evervault Dashboard (Data Roles section) and provide a mechanism for setting clear rules that dictate how and when data, tagged with that role, can be decrypted. For more details check out https://docs.evervault.com/sdks/go#reference
 
 evervault.EncryptString("hello world!", "allow-all");

--- a/e2e/encrypt_e2e_test.go
+++ b/e2e/encrypt_e2e_test.go
@@ -17,7 +17,7 @@ func TestE2EEncryptString(t *testing.T) {
 
 	payload := "hello world"
 
-	encrypted, err := client.EncryptString(payload, "")
+	encrypted, err := client.EncryptString(payload)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -42,7 +42,7 @@ func TestE2EEncryptStringWithPermittedRole(t *testing.T) {
 
 	payload := "hello world"
 
-	encrypted, err := client.EncryptString(payload, "permit-all")
+	encrypted, err := client.EncryptStringWithDataRole(payload, "permit-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -67,7 +67,7 @@ func TestE2EEncryptStringWithDeniedRole(t *testing.T) {
 
 	payload := "hello world"
 
-	encrypted, err := client.EncryptString(payload, "deny-all")
+	encrypted, err := client.EncryptStringWithDataRole(payload, "deny-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -87,7 +87,7 @@ func TestE2EEncryptBoolTrue(t *testing.T) {
 
 	payload := true
 
-	encrypted, err := client.EncryptBool(payload, "")
+	encrypted, err := client.EncryptBool(payload)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -112,7 +112,7 @@ func TestE2EEncryptBoolTrueWithPermittedRole(t *testing.T) {
 
 	payload := true
 
-	encrypted, err := client.EncryptBool(payload, "permit-all")
+	encrypted, err := client.EncryptBoolWithDataRole(payload, "permit-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -130,7 +130,6 @@ func TestE2EEncryptBoolTrueWithPermittedRole(t *testing.T) {
 	}
 }
 
-
 func TestE2EEncryptBoolTrueWithDeniedRole(t *testing.T) {
 	t.Parallel()
 
@@ -138,7 +137,7 @@ func TestE2EEncryptBoolTrueWithDeniedRole(t *testing.T) {
 
 	payload := true
 
-	encrypted, err := client.EncryptBool(payload, "deny-all")
+	encrypted, err := client.EncryptBoolWithDataRole(payload, "deny-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -158,7 +157,7 @@ func TestE2EEncryptBoolFalse(t *testing.T) {
 
 	payload := false
 
-	encrypted, err := client.EncryptBool(payload, "")
+	encrypted, err := client.EncryptBool(payload)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -183,7 +182,7 @@ func TestE2EEncryptBoolFalseWithPermittedRole(t *testing.T) {
 
 	payload := false
 
-	encrypted, err := client.EncryptBool(payload, "permit-all")
+	encrypted, err := client.EncryptBoolWithDataRole(payload, "permit-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -208,7 +207,7 @@ func TestE2EEncryptBoolFalseWithDeniedRole(t *testing.T) {
 
 	payload := false
 
-	encrypted, err := client.EncryptBool(payload, "deny-all")
+	encrypted, err := client.EncryptBoolWithDataRole(payload, "deny-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -228,7 +227,7 @@ func TestE2EEncryptInt(t *testing.T) {
 
 	payload := 1
 
-	encrypted, err := client.EncryptInt(payload, "")
+	encrypted, err := client.EncryptInt(payload)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -253,7 +252,7 @@ func TestE2EEncryptIntWithPermittedRole(t *testing.T) {
 
 	payload := 1
 
-	encrypted, err := client.EncryptInt(payload, "permit-all")
+	encrypted, err := client.EncryptIntWithDataRole(payload, "permit-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -278,7 +277,7 @@ func TestE2EEncryptIntWithDeniedRole(t *testing.T) {
 
 	payload := 1
 
-	encrypted, err := client.EncryptInt(payload, "deny-all")
+	encrypted, err := client.EncryptIntWithDataRole(payload, "deny-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -298,7 +297,7 @@ func TestE2EEncryptFloat(t *testing.T) {
 
 	payload := 1.5
 
-	encrypted, err := client.EncryptFloat64(payload, "")
+	encrypted, err := client.EncryptFloat64(payload)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -323,7 +322,7 @@ func TestE2EEncryptFloatWithPermittedRole(t *testing.T) {
 
 	payload := 1.5
 
-	encrypted, err := client.EncryptFloat64(payload, "permit-all")
+	encrypted, err := client.EncryptFloat64WithDataRole(payload, "permit-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -347,7 +346,7 @@ func TestE2EEncryptFloatWithDeniedRole(t *testing.T) {
 
 	payload := 1.5
 
-	encrypted, err := client.EncryptFloat64(payload, "deny-all")
+	encrypted, err := client.EncryptFloat64WithDataRole(payload, "deny-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -367,7 +366,7 @@ func TestE2EEncryptBytes(t *testing.T) {
 
 	payload := []byte{97, 98, 99, 100, 101, 102}
 
-	encrypted, err := client.EncryptByteArray(payload, "")
+	encrypted, err := client.EncryptByteArray(payload)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -384,7 +383,6 @@ func TestE2EEncryptBytes(t *testing.T) {
 		return
 	}
 }
-
 
 func TestE2EEncryptBytesWithPermittedRole(t *testing.T) {
 	t.Parallel()
@@ -393,7 +391,7 @@ func TestE2EEncryptBytesWithPermittedRole(t *testing.T) {
 
 	payload := []byte{97, 98, 99, 100, 101, 102}
 
-	encrypted, err := client.EncryptByteArray(payload, "permit-all")
+	encrypted, err := client.EncryptByteArrayWithDataRole(payload, "permit-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -411,7 +409,6 @@ func TestE2EEncryptBytesWithPermittedRole(t *testing.T) {
 	}
 }
 
-
 func TestE2EEncryptBytesWithDeniedRole(t *testing.T) {
 	t.Parallel()
 
@@ -419,7 +416,7 @@ func TestE2EEncryptBytesWithDeniedRole(t *testing.T) {
 
 	payload := []byte{97, 98, 99, 100, 101, 102}
 
-	encrypted, err := client.EncryptByteArray(payload, "deny-all")
+	encrypted, err := client.EncryptByteArrayWithDataRole(payload, "deny-all")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return

--- a/e2e/encrypt_e2e_test.go
+++ b/e2e/encrypt_e2e_test.go
@@ -17,7 +17,7 @@ func TestE2EEncryptString(t *testing.T) {
 
 	payload := "hello world"
 
-	encrypted, err := client.EncryptString(payload)
+	encrypted, err := client.EncryptString(payload, "")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -35,6 +35,51 @@ func TestE2EEncryptString(t *testing.T) {
 	}
 }
 
+func TestE2EEncryptStringWithPermittedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := "hello world"
+
+	encrypted, err := client.EncryptString(payload, "permit-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.DecryptString(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original %s %s", payload, decrypted)
+		return
+	}
+}
+
+func TestE2EEncryptStringWithDeniedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := "hello world"
+
+	encrypted, err := client.EncryptString(payload, "deny-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	_, err = client.DecryptString(encrypted)
+	if err == nil {
+		t.Errorf("expected error decrypting data")
+		return
+	}
+}
+
 func TestE2EEncryptBoolTrue(t *testing.T) {
 	t.Parallel()
 
@@ -42,7 +87,7 @@ func TestE2EEncryptBoolTrue(t *testing.T) {
 
 	payload := true
 
-	encrypted, err := client.EncryptBool(payload)
+	encrypted, err := client.EncryptBool(payload, "")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -56,6 +101,52 @@ func TestE2EEncryptBoolTrue(t *testing.T) {
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
+		return
+	}
+}
+
+func TestE2EEncryptBoolTrueWithPermittedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := true
+
+	encrypted, err := client.EncryptBool(payload, "permit-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.DecryptBool(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
+		return
+	}
+}
+
+
+func TestE2EEncryptBoolTrueWithDeniedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := true
+
+	encrypted, err := client.EncryptBool(payload, "deny-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	_, err = client.DecryptBool(encrypted)
+	if err == nil {
+		t.Errorf("expected error decrypting data")
 		return
 	}
 }
@@ -67,7 +158,7 @@ func TestE2EEncryptBoolFalse(t *testing.T) {
 
 	payload := false
 
-	encrypted, err := client.EncryptBool(payload)
+	encrypted, err := client.EncryptBool(payload, "")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -85,6 +176,51 @@ func TestE2EEncryptBoolFalse(t *testing.T) {
 	}
 }
 
+func TestE2EEncryptBoolFalseWithPermittedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := false
+
+	encrypted, err := client.EncryptBool(payload, "permit-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.DecryptBool(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
+		return
+	}
+}
+
+func TestE2EEncryptBoolFalseWithDeniedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := false
+
+	encrypted, err := client.EncryptBool(payload, "deny-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	_, err = client.DecryptBool(encrypted)
+	if err == nil {
+		t.Errorf("expected error decrypting data")
+		return
+	}
+}
+
 func TestE2EEncryptInt(t *testing.T) {
 	t.Parallel()
 
@@ -92,7 +228,7 @@ func TestE2EEncryptInt(t *testing.T) {
 
 	payload := 1
 
-	encrypted, err := client.EncryptInt(payload)
+	encrypted, err := client.EncryptInt(payload, "")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -110,6 +246,51 @@ func TestE2EEncryptInt(t *testing.T) {
 	}
 }
 
+func TestE2EEncryptIntWithPermittedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := 1
+
+	encrypted, err := client.EncryptInt(payload, "permit-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.DecryptInt(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original %d %d", payload, decrypted)
+		return
+	}
+}
+
+func TestE2EEncryptIntWithDeniedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := 1
+
+	encrypted, err := client.EncryptInt(payload, "deny-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	_, err = client.DecryptInt(encrypted)
+	if err == nil {
+		t.Errorf("expected error decrypting data")
+		return
+	}
+}
+
 func TestE2EEncryptFloat(t *testing.T) {
 	t.Parallel()
 
@@ -117,7 +298,7 @@ func TestE2EEncryptFloat(t *testing.T) {
 
 	payload := 1.5
 
-	encrypted, err := client.EncryptFloat64(payload)
+	encrypted, err := client.EncryptFloat64(payload, "")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -135,6 +316,50 @@ func TestE2EEncryptFloat(t *testing.T) {
 	}
 }
 
+func TestE2EEncryptFloatWithPermittedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := 1.5
+
+	encrypted, err := client.EncryptFloat64(payload, "permit-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.DecryptFloat64(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if payload != decrypted {
+		t.Errorf("decrypted data does not match the original %f %f", payload, decrypted)
+		return
+	}
+}
+func TestE2EEncryptFloatWithDeniedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := 1.5
+
+	encrypted, err := client.EncryptFloat64(payload, "deny-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	_, err = client.DecryptFloat64(encrypted)
+	if err == nil {
+		t.Errorf("expected error decrypting data")
+		return
+	}
+}
+
 func TestE2EEncryptBytes(t *testing.T) {
 	t.Parallel()
 
@@ -142,7 +367,7 @@ func TestE2EEncryptBytes(t *testing.T) {
 
 	payload := []byte{97, 98, 99, 100, 101, 102}
 
-	encrypted, err := client.EncryptByteArray(payload)
+	encrypted, err := client.EncryptByteArray(payload, "")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -156,6 +381,53 @@ func TestE2EEncryptBytes(t *testing.T) {
 
 	if string(payload) != string(decrypted) {
 		t.Errorf("decrypted data does not match the original %s %s", string(payload), string(decrypted))
+		return
+	}
+}
+
+
+func TestE2EEncryptBytesWithPermittedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := []byte{97, 98, 99, 100, 101, 102}
+
+	encrypted, err := client.EncryptByteArray(payload, "permit-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	decrypted, err := client.DecryptByteArray(encrypted)
+	if err != nil {
+		t.Errorf("error decrypting data %s", err)
+		return
+	}
+
+	if string(payload) != string(decrypted) {
+		t.Errorf("decrypted data does not match the original %s %s", string(payload), string(decrypted))
+		return
+	}
+}
+
+
+func TestE2EEncryptBytesWithDeniedRole(t *testing.T) {
+	t.Parallel()
+
+	client := GetClient(t)
+
+	payload := []byte{97, 98, 99, 100, 101, 102}
+
+	encrypted, err := client.EncryptByteArray(payload, "deny-all")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	_, err = client.DecryptByteArray(encrypted)
+	if err == nil {
+		t.Errorf("expected error decrypting data")
 		return
 	}
 }

--- a/e2e/function_e2e_test.go
+++ b/e2e/function_e2e_test.go
@@ -21,35 +21,35 @@ func TestE2EFunctionRun(t *testing.T) {
 
 	encryptedPayload := map[string]any{}
 
-	encrypted, err := client.EncryptString("hello", "")
+	encrypted, err := client.EncryptString("hello")
 	if err != nil {
 		t.Errorf("error encrypting string %s", err)
 		return
 	}
 	encryptedPayload["String"] = encrypted
 
-	encrypted, err = client.EncryptInt(1, "")
+	encrypted, err = client.EncryptInt(1)
 	if err != nil {
 		t.Errorf("error encrypting integer %s", err)
 		return
 	}
 	encryptedPayload["Integer"] = encrypted
 
-	encrypted, err = client.EncryptFloat64(1.5, "")
+	encrypted, err = client.EncryptFloat64(1.5)
 	if err != nil {
 		t.Errorf("error encrypting float %s", err)
 		return
 	}
 	encryptedPayload["Float"] = encrypted
 
-	encrypted, err = client.EncryptBool(true, "")
+	encrypted, err = client.EncryptBool(true)
 	if err != nil {
 		t.Errorf("error encrypting true %s", err)
 		return
 	}
 	encryptedPayload["True"] = encrypted
 
-	encrypted, err = client.EncryptBool(false, "")
+	encrypted, err = client.EncryptBool(false)
 	if err != nil {
 		t.Errorf("error encrypting false %s", err)
 		return

--- a/e2e/function_e2e_test.go
+++ b/e2e/function_e2e_test.go
@@ -66,11 +66,11 @@ func TestE2EFunctionRun(t *testing.T) {
 		t.Errorf("Expected success, got %s", runResult.Status)
 	}
 
-	assert.Equal(t, runResult.Result["String"], "string")
-	assert.Equal(t, runResult.Result["Integer"], "number")
-	assert.Equal(t, runResult.Result["Float"], "number")
-	assert.Equal(t, runResult.Result["True"], "boolean")
-	assert.Equal(t, runResult.Result["False"], "boolean")
+	assert.Equal(t, "string", runResult.Result["String"])
+	assert.Equal(t, "number", runResult.Result["Integer"])
+	assert.Equal(t, "number", runResult.Result["Float"])
+	assert.Equal(t, "boolean", runResult.Result["True"])
+	assert.Equal(t, "boolean", runResult.Result["False"])
 }
 
 func TestE2EFunctionRunWithError(t *testing.T) {
@@ -84,7 +84,7 @@ func TestE2EFunctionRunWithError(t *testing.T) {
 	if runtimeError, ok := err.(evervault.FunctionRuntimeError); !ok {
 		t.Error("Expected FunctionRuntimeError, got", err)
 	} else {
-		assert.Equal(t, runtimeError.ErrorBody.Message, "User threw an error")
+		assert.Equal(t, "User threw an error", runtimeError.ErrorBody.Message)
 	}
 }
 
@@ -99,6 +99,6 @@ func TestE2EFunctionRunWithInitializationError(t *testing.T) {
 	if runtimeError, ok := err.(evervault.FunctionRuntimeError); !ok {
 		t.Error("Expected FunctionRuntimeError, got", err)
 	} else {
-		assert.Equal(t, runtimeError.ErrorBody.Message, "The function failed to initialize. This error is commonly encountered when there are problems with the function code (e.g. a syntax error) or when a required import is missing.")
+		assert.Equal(t, "The function failed to initialize. This error is commonly encountered when there are problems with the function code (e.g. a syntax error) or when a required import is missing.", runtimeError.ErrorBody.Message)
 	}
 }

--- a/e2e/function_e2e_test.go
+++ b/e2e/function_e2e_test.go
@@ -21,35 +21,35 @@ func TestE2EFunctionRun(t *testing.T) {
 
 	encryptedPayload := map[string]any{}
 
-	encrypted, err := client.EncryptString("hello")
+	encrypted, err := client.EncryptString("hello", "")
 	if err != nil {
 		t.Errorf("error encrypting string %s", err)
 		return
 	}
 	encryptedPayload["String"] = encrypted
 
-	encrypted, err = client.EncryptInt(1)
+	encrypted, err = client.EncryptInt(1, "")
 	if err != nil {
 		t.Errorf("error encrypting integer %s", err)
 		return
 	}
 	encryptedPayload["Integer"] = encrypted
 
-	encrypted, err = client.EncryptFloat64(1.5)
+	encrypted, err = client.EncryptFloat64(1.5, "")
 	if err != nil {
 		t.Errorf("error encrypting float %s", err)
 		return
 	}
 	encryptedPayload["Float"] = encrypted
 
-	encrypted, err = client.EncryptBool(true)
+	encrypted, err = client.EncryptBool(true, "")
 	if err != nil {
 		t.Errorf("error encrypting true %s", err)
 		return
 	}
 	encryptedPayload["True"] = encrypted
 
-	encrypted, err = client.EncryptBool(false)
+	encrypted, err = client.EncryptBool(false, "")
 	if err != nil {
 		t.Errorf("error encrypting false %s", err)
 		return

--- a/e2e/outbound_e2e_test.go
+++ b/e2e/outbound_e2e_test.go
@@ -18,42 +18,42 @@ func TestE2EOutboundRelay(t *testing.T) {
 
 	client := GetClient(t)
 
-	encryptedString, err := client.EncryptString("some_string", "")
+	encryptedString, err := client.EncryptString("some_string")
 	if err != nil {
 		t.Errorf("error encrypting string %s", err)
 		return
 	}
 
-	encryptedNumber, err := client.EncryptInt(1234567890, "")
+	encryptedNumber, err := client.EncryptInt(1234567890)
 	if err != nil {
 		t.Errorf("error encrypting number %s", err)
 		return
 	}
-	
-	encryptedBool, err := client.EncryptBool(true, "")
+
+	encryptedBool, err := client.EncryptBool(true)
 	if err != nil {
 		t.Errorf("error encrypting bool %s", err)
 		return
 	}
 
 	outboundRelayClient, err := client.OutboundRelayClient()
-    if err != nil {
+	if err != nil {
 		t.Errorf("Error getting outbound client %s", err)
 		return
-    }
+	}
 
 	data := map[string]string{"string": encryptedString, "number": encryptedNumber, "boolean": encryptedBool}
-    payload, err := json.Marshal(data)
-    if err != nil {
-        t.Errorf("error Marshalling payload %s", err)
+	payload, err := json.Marshal(data)
+	if err != nil {
+		t.Errorf("error Marshalling payload %s", err)
 		return
-    }
+	}
 
-    resp, err := outboundRelayClient.Post(syntheticEndpointUrl, "application/json", bytes.NewReader(payload))
-    if err != nil {
-        t.Errorf("error posting with outbound client %s", err)
+	resp, err := outboundRelayClient.Post(syntheticEndpointUrl, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Errorf("error posting with outbound client %s", err)
 		return
-    }
+	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/e2e/outbound_e2e_test.go
+++ b/e2e/outbound_e2e_test.go
@@ -18,19 +18,19 @@ func TestE2EOutboundRelay(t *testing.T) {
 
 	client := GetClient(t)
 
-	encryptedString, err := client.EncryptString("some_string")
+	encryptedString, err := client.EncryptString("some_string", "")
 	if err != nil {
 		t.Errorf("error encrypting string %s", err)
 		return
 	}
 
-	encryptedNumber, err := client.EncryptInt(1234567890)
+	encryptedNumber, err := client.EncryptInt(1234567890, "")
 	if err != nil {
 		t.Errorf("error encrypting number %s", err)
 		return
 	}
 	
-	encryptedBool, err := client.EncryptBool(true)
+	encryptedBool, err := client.EncryptBool(true, "")
 	if err != nil {
 		t.Errorf("error encrypting bool %s", err)
 		return

--- a/evervault.go
+++ b/evervault.go
@@ -97,7 +97,8 @@ func (c *Client) EncryptString(value, role string) (string, error) {
 		return "", err
 	}
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, value, role, datatypes.String)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, value, role,
+		datatypes.String)
 }
 
 // EncryptInt encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -115,7 +116,8 @@ func (c *Client) EncryptInt(value int, role string) (string, error) {
 
 	val := strconv.Itoa(value)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.Number)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val,
+		role, datatypes.Number)
 }
 
 // EncryptFloat64 encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -133,7 +135,8 @@ func (c *Client) EncryptFloat64(value float64, role string) (string, error) {
 
 	val := strconv.FormatFloat(value, 'f', -1, 64)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.Number)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role,
+		datatypes.Number)
 }
 
 // EncryptBool encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -151,7 +154,8 @@ func (c *Client) EncryptBool(value bool, role string) (string, error) {
 
 	val := strconv.FormatBool(value)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.Boolean)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role,
+		datatypes.Boolean)
 }
 
 // EncryptByteArray encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -169,7 +173,8 @@ func (c *Client) EncryptByteArray(value []byte, role string) (string, error) {
 
 	val := string(value)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.String)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role,
+		datatypes.String)
 }
 
 // DecryptString decrypts data previously encrypted with Encrypt or through Relay

--- a/evervault.go
+++ b/evervault.go
@@ -91,7 +91,19 @@ func (c *Client) getAesKeyAndCompressedEphemeralPublicKey() ([]byte, []byte, err
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptString(value, role string) (string, error) {
+func (c *Client) EncryptString(value string) (string, error) {
+	return c.EncryptStringWithDataRole(value, "")
+}
+
+// EncryptString encrypts the value passed to it using the Evervault Encryption Scheme.
+// The data role included is embedded in the encrypted string and can be used to control access to the data.
+// The encrypted value is returned as an Evervault formatted encrypted string.
+//
+//	encrypted := evClient.EncryptString("Hello, world!");
+//
+// If an error occurs then nil is returned. If the error is due a problem with Key creation then
+// ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
+func (c *Client) EncryptStringWithDataRole(value, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -108,7 +120,19 @@ func (c *Client) EncryptString(value, role string) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptInt(value int, role string) (string, error) {
+func (c *Client) EncryptInt(value int) (string, error) {
+	return c.EncryptIntWithDataRole(value, "")
+}
+
+// EncryptInt encrypts the value passed to it using the Evervault Encryption Scheme.
+// The data role included is embedded in the encrypted string and can be used to control access to the data.
+// The encrypted value is returned as an Evervault formatted encrypted string.
+//
+//	encrypted := evClient.EncryptInt(100);
+//
+// If an error occurs then nil is returned. If the error is due a problem with Key creation then
+// ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
+func (c *Client) EncryptIntWithDataRole(value int, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -127,7 +151,19 @@ func (c *Client) EncryptInt(value int, role string) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptFloat64(value float64, role string) (string, error) {
+func (c *Client) EncryptFloat64(value float64) (string, error) {
+	return c.EncryptFloat64WithDataRole(value, "")
+}
+
+// EncryptFloat64 encrypts the value passed to it using the Evervault Encryption Scheme.
+// The data role included is embedded in the encrypted string and can be used to control access to the data.
+// The encrypted value is returned as an Evervault formatted encrypted string.
+//
+//	encrypted := evClient.EncryptInt(100.1);
+//
+// If an error occurs then nil is returned. If the error is due a problem with Key creation then
+// ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
+func (c *Client) EncryptFloat64WithDataRole(value float64, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -146,7 +182,19 @@ func (c *Client) EncryptFloat64(value float64, role string) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptBool(value bool, role string) (string, error) {
+func (c *Client) EncryptBool(value bool) (string, error) {
+	return c.EncryptBoolWithDataRole(value, "")
+}
+
+// EncryptBool encrypts the value passed to it using the Evervault Encryption Scheme.
+// The data role included is embedded in the encrypted string and can be used to control access to the data.
+// The encrypted value is returned as an Evervault formatted encrypted string.
+//
+//	encrypted := evClient.EncryptBool(true);
+//
+// If an error occurs then nil is returned. If the error is due a problem with Key creation then
+// ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
+func (c *Client) EncryptBoolWithDataRole(value bool, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -165,7 +213,19 @@ func (c *Client) EncryptBool(value bool, role string) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptByteArray(value []byte, role string) (string, error) {
+func (c *Client) EncryptByteArray(value []byte) (string, error) {
+	return c.EncryptByteArrayWithDataRole(value, "")
+}
+
+// EncryptByteArray encrypts the value passed to it using the Evervault Encryption Scheme.
+// The data role included is embedded in the encrypted string and can be used to control access to the data.
+// The encrypted value is returned as an Evervault formatted encrypted string.
+//
+//	encrypted := evClient.EncryptByteArray([]byte("Hello, world!"));
+//
+// If an error occurs then nil is returned. If the error is due a problem with Key creation then
+// ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
+func (c *Client) EncryptByteArrayWithDataRole(value []byte, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err

--- a/evervault.go
+++ b/evervault.go
@@ -91,13 +91,13 @@ func (c *Client) getAesKeyAndCompressedEphemeralPublicKey() ([]byte, []byte, err
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptString(value string) (string, error) {
+func (c *Client) EncryptString(value, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
 	}
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, value, datatypes.String)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, value, role, datatypes.String)
 }
 
 // EncryptInt encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -107,7 +107,7 @@ func (c *Client) EncryptString(value string) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptInt(value int) (string, error) {
+func (c *Client) EncryptInt(value int, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -115,7 +115,7 @@ func (c *Client) EncryptInt(value int) (string, error) {
 
 	val := strconv.Itoa(value)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, datatypes.Number)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.Number)
 }
 
 // EncryptFloat64 encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -125,7 +125,7 @@ func (c *Client) EncryptInt(value int) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptFloat64(value float64) (string, error) {
+func (c *Client) EncryptFloat64(value float64, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -133,7 +133,7 @@ func (c *Client) EncryptFloat64(value float64) (string, error) {
 
 	val := strconv.FormatFloat(value, 'f', -1, 64)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, datatypes.Number)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.Number)
 }
 
 // EncryptBool encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -143,7 +143,7 @@ func (c *Client) EncryptFloat64(value float64) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptBool(value bool) (string, error) {
+func (c *Client) EncryptBool(value bool, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -151,7 +151,7 @@ func (c *Client) EncryptBool(value bool) (string, error) {
 
 	val := strconv.FormatBool(value)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, datatypes.Boolean)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.Boolean)
 }
 
 // EncryptByteArray encrypts the value passed to it using the Evervault Encryption Scheme.
@@ -161,7 +161,7 @@ func (c *Client) EncryptBool(value bool) (string, error) {
 //
 // If an error occurs then nil is returned. If the error is due a problem with Key creation then
 // ErrCryptoKeyImportError is returned. For anyother error ErrCryptoUnableToPerformEncryption is returned.
-func (c *Client) EncryptByteArray(value []byte) (string, error) {
+func (c *Client) EncryptByteArray(value []byte, role string) (string, error) {
 	aesKey, compressedEphemeralPublicKey, err := c.getAesKeyAndCompressedEphemeralPublicKey()
 	if err != nil {
 		return "", err
@@ -169,7 +169,7 @@ func (c *Client) EncryptByteArray(value []byte) (string, error) {
 
 	val := string(value)
 
-	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, datatypes.String)
+	return crypto.EncryptValue(aesKey, compressedEphemeralPublicKey, c.p256PublicKeyCompressed, val, role, datatypes.String)
 }
 
 // DecryptString decrypts data previously encrypted with Encrypt or through Relay

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -178,7 +178,26 @@ func TestEncryptString(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptString("plaintext")
+	res, err := testClient.EncryptString("plaintext", "")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	if !isValidEncryptedString(res, datatypes.String) {
+		t.Errorf("Expected encrypted string, got %s", res)
+	}
+}
+
+func TestEncryptStringWithMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := startMockHTTPServer("", "")
+	defer server.Close()
+
+	testClient := mockedClient(t, server)
+
+	res, err := testClient.EncryptString("plaintext", "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -197,7 +216,26 @@ func TestEncryptInt(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptInt(123)
+	res, err := testClient.EncryptInt(123, "")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	if !isValidEncryptedString(res, datatypes.Number) {
+		t.Errorf("Expected encrypted string, got %s", res)
+	}
+}
+
+func TestEncryptIntWithRole(t *testing.T) {
+	t.Parallel()
+
+	server := startMockHTTPServer("", "")
+	defer server.Close()
+
+	testClient := mockedClient(t, server)
+
+	res, err := testClient.EncryptInt(123, "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -216,7 +254,26 @@ func TestEncryptFloat64(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptFloat64(1.1)
+	res, err := testClient.EncryptFloat64(1.1, "")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	if !isValidEncryptedString(res, datatypes.Number) {
+		t.Errorf("Expected encrypted string, got %s", res)
+	}
+}
+
+func TestEncryptFloat64WithRole(t *testing.T) {
+	t.Parallel()
+
+	server := startMockHTTPServer("", "")
+	defer server.Close()
+
+	testClient := mockedClient(t, server)
+
+	res, err := testClient.EncryptFloat64(1.1, "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -235,7 +292,26 @@ func TestEncryptBoolean(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptBool(true)
+	res, err := testClient.EncryptBool(true, "")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	if !isValidEncryptedString(res, datatypes.Boolean) {
+		t.Errorf("Expected encrypted string, got %s", res)
+	}
+}
+
+func TestEncryptBooleanWithRole(t *testing.T) {
+	t.Parallel()
+
+	server := startMockHTTPServer("", "")
+	defer server.Close()
+
+	testClient := mockedClient(t, server)
+
+	res, err := testClient.EncryptBool(true, "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -254,7 +330,26 @@ func TestEncryptByte(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptByteArray([]byte("plaintext"))
+	res, err := testClient.EncryptByteArray([]byte("plaintext"), "")
+	if err != nil {
+		t.Errorf("error encrypting data %s", err)
+		return
+	}
+
+	if !isValidEncryptedString(res, datatypes.String) {
+		t.Errorf("Expected encrypted string, got %s", res)
+	}
+}
+
+func TestEncryptByteWithRole(t *testing.T) {
+	t.Parallel()
+
+	server := startMockHTTPServer("", "")
+	defer server.Close()
+
+	testClient := mockedClient(t, server)
+
+	res, err := testClient.EncryptByteArray([]byte("plaintext"), "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -178,7 +178,7 @@ func TestEncryptString(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptString("plaintext", "")
+	res, err := testClient.EncryptString("plaintext")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -189,7 +189,7 @@ func TestEncryptString(t *testing.T) {
 	}
 }
 
-func TestEncryptStringWithMetadata(t *testing.T) {
+func TestEncryptStringWithRole(t *testing.T) {
 	t.Parallel()
 
 	server := startMockHTTPServer("", "")
@@ -197,7 +197,7 @@ func TestEncryptStringWithMetadata(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptString("plaintext", "role")
+	res, err := testClient.EncryptStringWithDataRole("plaintext", "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -216,7 +216,7 @@ func TestEncryptInt(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptInt(123, "")
+	res, err := testClient.EncryptInt(123)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -235,7 +235,7 @@ func TestEncryptIntWithRole(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptInt(123, "role")
+	res, err := testClient.EncryptIntWithDataRole(123, "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -254,7 +254,7 @@ func TestEncryptFloat64(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptFloat64(1.1, "")
+	res, err := testClient.EncryptFloat64(1.1)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -273,7 +273,7 @@ func TestEncryptFloat64WithRole(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptFloat64(1.1, "role")
+	res, err := testClient.EncryptFloat64WithDataRole(1.1, "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -292,7 +292,7 @@ func TestEncryptBoolean(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptBool(true, "")
+	res, err := testClient.EncryptBool(true)
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -311,7 +311,7 @@ func TestEncryptBooleanWithRole(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptBool(true, "role")
+	res, err := testClient.EncryptBoolWithDataRole(true, "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -330,7 +330,7 @@ func TestEncryptByte(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptByteArray([]byte("plaintext"), "")
+	res, err := testClient.EncryptByteArray([]byte("plaintext"))
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return
@@ -349,7 +349,7 @@ func TestEncryptByteWithRole(t *testing.T) {
 
 	testClient := mockedClient(t, server)
 
-	res, err := testClient.EncryptByteArray([]byte("plaintext"), "role")
+	res, err := testClient.EncryptByteArrayWithDataRole([]byte("plaintext"), "role")
 	if err != nil {
 		t.Errorf("error encrypting data %s", err)
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	encrypted, err := evClient.EncryptString("Hello, world!")
+	encrypted, err := evClient.EncryptString("Hello, world!", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func ExampleClient_Encrypt() {
 		log.Fatal(err)
 	}
 
-	encrypted, err := evClient.EncryptString("Hello, world!")
+	encrypted, err := evClient.EncryptString("Hello, world!", "")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	encrypted, err := evClient.EncryptString("Hello, world!", "")
+	encrypted, err := evClient.EncryptString("Hello, world!")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func ExampleClient_Encrypt() {
 		log.Fatal(err)
 	}
 
-	encrypted, err := evClient.EncryptString("Hello, world!", "")
+	encrypted, err := evClient.EncryptString("Hello, world!")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/function.go
+++ b/function.go
@@ -74,8 +74,8 @@ func (c *Client) createRunToken(functionName string, payload any) (RunTokenRespo
 
 func (c *Client) runFunction(functionName string, payload map[string]any) (FunctionRunResponse, error) {
 	wrappedPayload := map[string]any{"payload": payload}
-	pBytes, err := json.Marshal(wrappedPayload)
 
+	pBytes, err := json.Marshal(wrappedPayload)
 	if err != nil {
 		return FunctionRunResponse{}, fmt.Errorf("Error parsing payload as json %w", err)
 	}

--- a/function_test.go
+++ b/function_test.go
@@ -39,7 +39,7 @@ func TestRunFunctionSuccess(t *testing.T) {
 		"status": "success",
 		"result": { "message": "%s" },
 		"id": "%s"
-	}`, message, id);
+	}`, message, id)
 
 	server := startMockHTTPServer(functionResponsePayload, "")
 	defer server.Close()
@@ -53,9 +53,9 @@ func TestRunFunctionSuccess(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, res.Status, "success")
-	assert.Equal(t, res.ID, id)
-	assert.Equal(t, res.Result["message"], message)
+	assert.Equal(t, "success", res.Status)
+	assert.Equal(t, id, res.ID)
+	assert.Equal(t, message, res.Result["message"])
 }
 
 func TestRunFunctionFailure(t *testing.T) {
@@ -69,7 +69,7 @@ func TestRunFunctionFailure(t *testing.T) {
 		"status": "failure",
 		"error": { "message": "%s", "stack": "%s" },
 		"id": "%s"
-	}`, message, stack, id);
+	}`, message, stack, id)
 
 	server := startMockHTTPServer(functionResponsePayload, "")
 	defer server.Close()
@@ -81,9 +81,9 @@ func TestRunFunctionFailure(t *testing.T) {
 	if runtimeError, ok := err.(evervault.FunctionRuntimeError); !ok {
 		t.Error("Expected FunctionRuntimeError, got", err)
 	} else {
-		assert.Equal(t, runtimeError.ErrorBody.Message, message)
-		assert.Equal(t, runtimeError.ErrorBody.Stack, stack)
-		assert.Equal(t, runtimeError.ID, id)
+		assert.Equal(t, message, runtimeError.ErrorBody.Message)
+		assert.Equal(t, stack, runtimeError.ErrorBody.Stack)
+		assert.Equal(t, id, runtimeError.ID)
 	}
 }
 
@@ -109,7 +109,7 @@ func TestRunFunctionTimeout(t *testing.T) {
 	if functionTimeoutError, ok := err.(evervault.FunctionTimeoutError); !ok {
 		t.Error("Expected FunctionTimeoutError, got", err)
 	} else {
-		assert.Equal(t, functionTimeoutError.Message, message)
+		assert.Equal(t, message, functionTimeoutError.Message)
 	}
 }
 
@@ -135,7 +135,7 @@ func TestRunFunctionNotReady(t *testing.T) {
 	if functionNotReadyError, ok := err.(evervault.FunctionNotReadyError); !ok {
 		t.Error("Expected FunctionNotReadyError, got", err)
 	} else {
-		assert.Equal(t, functionNotReadyError.Message, message)
+		assert.Equal(t, message, functionNotReadyError.Message)
 	}
 }
 
@@ -162,7 +162,7 @@ func TestRunFunctionUnauthorized(t *testing.T) {
 	if evervaultError, ok := err.(evervault.APIError); !ok {
 		t.Error("Expected Evervault Error, got", err)
 	} else {
-		assert.Equal(t, evervaultError.Code, code)
-		assert.Equal(t, evervaultError.Message, message)
+		assert.Equal(t, code, evervaultError.Code)
+		assert.Equal(t, message, evervaultError.Message)
 	}
 }

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -119,18 +119,18 @@ func buildEncodedMetadata(role string) ([]byte, error) {
 			return nil, fmt.Errorf("error building metadata %w", err)
 		}
 
-		err = encodeRole(buffer, role)
+		err = encodeRole(&buffer, role)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	err := encodeEncryptionOrigin(buffer)
+	err := encodeEncryptionOrigin(&buffer)
 	if err != nil {
 		return nil, err
 	}
 
-	err = encodeEncryptionTimestamp(buffer)
+	err = encodeEncryptionTimestamp(&buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -138,10 +138,10 @@ func buildEncodedMetadata(role string) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-func encodeEncryptionTimestamp(buffer bytes.Buffer) error {
+func encodeEncryptionTimestamp(buffer *bytes.Buffer) error {
 	// "et" (encryption timestamp) => current time
 	// Binary representation for a fixed string of length 2, followed by `et`
-	err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
+	err := binary.Write(buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
 	if err != nil {
 		return fmt.Errorf("error building metadata %w", err)
 	}
@@ -152,7 +152,7 @@ func encodeEncryptionTimestamp(buffer bytes.Buffer) error {
 	}
 
 	// Binary representation for a 4-byte unsigned integer (uint 32), followed by the epoch time
-	err = binary.Write(&buffer, binary.BigEndian, byte(binaryRepresentationOfFourByteUnsignedInteger))
+	err = binary.Write(buffer, binary.BigEndian, byte(binaryRepresentationOfFourByteUnsignedInteger))
 	if err != nil {
 		return fmt.Errorf("error building metadata %w", err)
 	}
@@ -160,7 +160,7 @@ func encodeEncryptionTimestamp(buffer bytes.Buffer) error {
 	// Get the current time and convert it to Unix timestamp (seconds since Jan 1, 1970)
 	currentTime := uint32(time.Now().Unix())
 
-	err = binary.Write(&buffer, binary.BigEndian, currentTime)
+	err = binary.Write(buffer, binary.BigEndian, currentTime)
 	if err != nil {
 		return fmt.Errorf("error building metadata %w", err)
 	}
@@ -168,10 +168,10 @@ func encodeEncryptionTimestamp(buffer bytes.Buffer) error {
 	return nil
 }
 
-func encodeEncryptionOrigin(buffer bytes.Buffer) error {
+func encodeEncryptionOrigin(buffer *bytes.Buffer) error {
 	// "eo" (encryption origin) => 9 (Go SDK)
 	// Binary representation for a fixed string of length 2, followed by `eo`
-	err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
+	err := binary.Write(buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
 	if err != nil {
 		return fmt.Errorf("error building metadata %w", err)
 	}
@@ -182,7 +182,7 @@ func encodeEncryptionOrigin(buffer bytes.Buffer) error {
 	}
 
 	// Binary representation for the integer 9
-	err = binary.Write(&buffer, binary.BigEndian, byte(encryptionOrigin))
+	err = binary.Write(buffer, binary.BigEndian, byte(encryptionOrigin))
 	if err != nil {
 		return fmt.Errorf("error building metadata %w", err)
 	}
@@ -190,10 +190,10 @@ func encodeEncryptionOrigin(buffer bytes.Buffer) error {
 	return nil
 }
 
-func encodeRole(buffer bytes.Buffer, role string) error {
+func encodeRole(buffer *bytes.Buffer, role string) error {
 	// `dr` (data role) => role_name
 	// Binary representation for a fixed string of length 2, followed by `dr`
-	err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
+	err := binary.Write(buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
 	if err != nil {
 		return fmt.Errorf("error building metadata %w", err)
 	}
@@ -204,7 +204,7 @@ func encodeRole(buffer bytes.Buffer, role string) error {
 	}
 
 	// Binary representation for a fixed string of role name length, followed by the role name itself.
-	err = binary.Write(&buffer, binary.BigEndian, byte(defaultRoleNameLength|len(role)))
+	err = binary.Write(buffer, binary.BigEndian, byte(defaultRoleNameLength|len(role)))
 	if err != nil {
 		return fmt.Errorf("error building metadata %w", err)
 	}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -25,6 +25,13 @@ const (
 		"26b7819f7e900441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0" +
 		"f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63255102" +
 		"0101034200"
+	metadataOffsetLength                          = 0x02
+	lengthOfTwoMetadataItems                      = 0x82
+	lengthOfThreeMetadataItems                    = 0x83
+	lengthOfFixedLengthStringWith2Bytes           = 0xa2
+	encryptionOrigin                              = 0x09
+	defaultRoleNameLength                         = 0xa0
+	binaryRepresentationOfFourByteUnsignedInteger = 0xce
 )
 
 // DeriveKDFAESKey derives an AES key using the given public key and shared ECDH secret.
@@ -76,57 +83,138 @@ func EncryptValue(
 		return "", fmt.Errorf("unable to encrypt block %w", err)
 	}
 
-	metadata := buildEncodedMetadata(role)
-	metadataLength := uint16(len(metadata))
-	metadataOffset := make([]byte, 2)
-	binary.LittleEndian.PutUint16(metadataOffset, metadataLength)
-	value_with_metadata := append(append(metadataOffset, metadata...), []byte(value)...)
+	metadata, err := buildEncodedMetadata(role)
+	if err != nil {
+		return "", fmt.Errorf("unable to build metadata %w", err)
+	}
 
-	ciphertext := aesgcm.Seal(nil, nonce, value_with_metadata, appPublicKey)
+	// Get the concatenated result as a byte slice
+	metadataOffset := make([]byte, metadataOffsetLength)
+	binary.LittleEndian.PutUint16(metadataOffset, uint16(len(metadata)))
+
+	var buffer bytes.Buffer
+
+	buffer.Write(metadataOffset)
+	buffer.Write(metadata)
+	buffer.WriteString(value)
+	valueWithMetadata := buffer.Bytes()
+
+	ciphertext := aesgcm.Seal(nil, nonce, valueWithMetadata, appPublicKey)
 
 	return evFormat(ciphertext, nonce, ephemeralPublicKey, datatype), nil
 }
 
-func buildEncodedMetadata(role string) []byte {
+func buildEncodedMetadata(role string) ([]byte, error) {
 	var buffer bytes.Buffer
 
 	// Binary representation of a fixed map with 2 or 3 items, followed by the key-value pairs.
 	if role == "" {
-		binary.Write(&buffer, binary.BigEndian, byte(0x82))
+		err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfTwoMetadataItems))
+		if err != nil {
+			return nil, fmt.Errorf("error building metadata %w", err)
+		}
 	} else {
-		binary.Write(&buffer, binary.BigEndian, byte(0x83))
+		err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfThreeMetadataItems))
+		if err != nil {
+			return nil, fmt.Errorf("error building metadata %w", err)
+		}
 
-		// `dr` (data role) => role_name
-		// Binary representation for a fixed string of length 2, followed by `dr`
-		binary.Write(&buffer, binary.BigEndian, byte(0xa2))
-		buffer.WriteString("dr")
-
-		// Binary representation for a fixed string of role name length, followed by the role name itself.
-		binary.Write(&buffer, binary.BigEndian, byte(0xa0|len(role)))
-		buffer.WriteString(role)
+		err = encodeRole(buffer, role)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// "eo" (encryption origin) => 9 (Go SDK)
-	// Binary representation for a fixed string of length 2, followed by `eo`
-	binary.Write(&buffer, binary.BigEndian, byte(0xa2))
-	buffer.WriteString("eo")
+	err := encodeEncryptionOrigin(buffer)
+	if err != nil {
+		return nil, err
+	}
 
-	// Binary representation for the integer 9
-	binary.Write(&buffer, binary.BigEndian, byte(0x09))
+	err = encodeEncryptionTimestamp(buffer)
+	if err != nil {
+		return nil, err
+	}
 
+	return buffer.Bytes(), nil
+}
+
+func encodeEncryptionTimestamp(buffer bytes.Buffer) error {
 	// "et" (encryption timestamp) => current time
 	// Binary representation for a fixed string of length 2, followed by `et`
-	binary.Write(&buffer, binary.BigEndian, byte(0xa2))
-	buffer.WriteString("et")
+	err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	_, err = buffer.WriteString("et")
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	// Binary representation for a 4-byte unsigned integer (uint 32), followed by the epoch time
+	err = binary.Write(&buffer, binary.BigEndian, byte(binaryRepresentationOfFourByteUnsignedInteger))
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
 
 	// Get the current time and convert it to Unix timestamp (seconds since Jan 1, 1970)
 	currentTime := uint32(time.Now().Unix())
 
-	// Binary representation for a 4-byte unsigned integer (uint 32), followed by the epoch time
-	binary.Write(&buffer, binary.BigEndian, byte(0xce))
-	binary.Write(&buffer, binary.BigEndian, currentTime)
+	err = binary.Write(&buffer, binary.BigEndian, currentTime)
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
 
-	return buffer.Bytes()
+	return nil
+}
+
+func encodeEncryptionOrigin(buffer bytes.Buffer) error {
+	// "eo" (encryption origin) => 9 (Go SDK)
+	// Binary representation for a fixed string of length 2, followed by `eo`
+	err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	_, err = buffer.WriteString("eo")
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	// Binary representation for the integer 9
+	err = binary.Write(&buffer, binary.BigEndian, byte(encryptionOrigin))
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	return nil
+}
+
+func encodeRole(buffer bytes.Buffer, role string) error {
+	// `dr` (data role) => role_name
+	// Binary representation for a fixed string of length 2, followed by `dr`
+	err := binary.Write(&buffer, binary.BigEndian, byte(lengthOfFixedLengthStringWith2Bytes))
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	_, err = buffer.WriteString("dr")
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	// Binary representation for a fixed string of role name length, followed by the role name itself.
+	err = binary.Write(&buffer, binary.BigEndian, byte(defaultRoleNameLength|len(role)))
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	_, err = buffer.WriteString(role)
+	if err != nil {
+		return fmt.Errorf("error building metadata %w", err)
+	}
+
+	return nil
 }
 
 // evFormat formats the cipher text, IV, public key, and datatype into an "ev" formatted string.


### PR DESCRIPTION
# Why

Data roles need to be embedded in the ciphertext to support data policies

# How

Embedding the data role in the ciphertext
