### PR TITLE
Add enclave functions and introduce deprecation notice to cage functions

### DIFF
--- a/.changeset/modern-pigs-deliver.md
+++ b/.changeset/modern-pigs-deliver.md
@@ -2,7 +2,7 @@
 "evervault-go": minor
 ---
 
-Introduce enclave functions to GoSDK and add a deprecation notice to the existing Cage functions. Users of the Cages Client are encouraged to migrate to the new Enclave Client.
+Introduce enclave functions to the Go SDK and add a deprecation notice to the existing Cage functions. Users of the Cages Client are encouraged to migrate to the new Enclave Client.
 
 Users of the `CagesClient` should be able to directly replace with the `EnclaveClient` as follows:
 

--- a/.changeset/modern-pigs-deliver.md
+++ b/.changeset/modern-pigs-deliver.md
@@ -1,0 +1,55 @@
+---
+"evervault-go": minor
+---
+
+Introduce enclave functions to GoSDK and add a deprecation notice to the existing Cage functions. Users of the Cages Client are encouraged to migrate to the new Enclave Client.
+
+Users of the `CagesClient` should be able to directly replace with the `EnclaveClient` as follows:
+
+```go
+// Deprecated Cage client implementation
+cageURL = "<CAGE_NAME>.<APP_UUID>.cages.evervault.com"
+expectedPCRs := evervault.PCRs{
+  PCR0: "f039c31c536749ac6b2a9344fcb36881dd1cf066ca44afcaf9369a9877e2d3c85fa738c427d502e01e35994da7458e2d",
+  PCR1: "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
+  PCR2: "71c478711438fe252fbd9b1da56218bea5d630da55aa56431257df77bd42f65a434601bf53be9a1901fcd61680e425c7",
+  PCR8: "1650274b27bf44fba6f1779602399763af9e4567927d771b1b37aeb1ac502c84fbd6a7ab7b05600656a257247529fbb8",
+}
+
+cageClient, err := evClient.CagesClient(cageURL, []evervault.PCRs{expectedPCRs})
+
+// Updated Enclave client implementation
+enclaveURL = "<ENCLAVE_NAME>.<APP_UUID>.enclave.evervault.com"
+expectedPCRs := evervault.PCRs{
+  PCR0: "f039c31c536749ac6b2a9344fcb36881dd1cf066ca44afcaf9369a9877e2d3c85fa738c427d502e01e35994da7458e2d",
+  PCR1: "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
+  PCR2: "71c478711438fe252fbd9b1da56218bea5d630da55aa56431257df77bd42f65a434601bf53be9a1901fcd61680e425c7",
+  PCR8: "1650274b27bf44fba6f1779602399763af9e4567927d771b1b37aeb1ac502c84fbd6a7ab7b05600656a257247529fbb8",
+}
+
+enclaveClient, err := evClient.EnclaveClient(enclaveURL, []evervault.PCRs{expectedPCRs})
+```
+
+Users of the newer Clients with Providers should follow a similar migration pattern:
+
+```go
+// Deprecated Cage client implementation
+cageURL = "<CAGE_NAME>.<APP_UUID>.cages.evervault.com"
+func GetPCRs() ([]attestation.PCRs, error) {
+  // logic to get PCRs
+  return pcrs, nil
+}
+
+cageClient, err := evClient.CagesClientWithProvider(cageURL, GetPCRs)
+
+// Updated Enclave client implementation
+enclaveURL = "<ENCLAVE_NAME>.<APP_UUID>.enclave.evervault.com"
+func GetPCRs() ([]attestation.PCRs, error) {
+  // logic to get PCRs
+  return pcrs, nil
+}
+
+enclaveClient, err := evClient.EnclaveClientWithProvider(enclaveURL, GetPCRs)
+```
+
+We also recommend users of the Provider pattern update their custom polling interval environment variable from `EV_CAGES_POLLING_INTERVAL` to `EV_ATTESTATION_POLLING_INTERVAL` where relevant.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,7 @@ jobs:
         env:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID_V1 }}
           EV_API_KEY: ${{ secrets.EV_API_KEY_V1 }}
+          EV_ENCLAVE_API_KEY: ${{ secrets.EV_ENCLAVE_API_KEY }}
           EV_FUNCTION_NAME: ${{ secrets.EV_FUNCTION_NAME_V1 }}
           EV_INITIALIZATION_ERROR_FUNCTION_NAME: ${{ secrets.EV_INITIALIZATION_ERROR_FUNCTION_NAME }}
           EV_SYNTHETIC_ENDPOINT_URL: ${{ secrets.EV_SYNTHETIC_ENDPOINT_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,5 @@ jobs:
         env:
           EV_APP_UUID: ${{ secrets.EV_APP_UUID }}
           EV_API_KEY: ${{ secrets.EV_API_KEY }}
+          EV_ENCLAVE_API_KEY: ${{ secrets.EV_ENCLAVE_API_KEY }}
         run: go test -v -count=1 -race --tags=unit_test ./... 

--- a/attest.go
+++ b/attest.go
@@ -1,0 +1,127 @@
+package evervault
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/evervault/evervault-go/attestation"
+	internalAttestation "github.com/evervault/evervault-go/internal/attestation"
+	"github.com/hf/nitrite"
+)
+
+// mapAttestationPCRs maps the attestation document's PCRs to a PCRs struct.
+func mapAttestationPCRs(attestationPCRs nitrite.Document) attestation.PCRs {
+	// We verify a subset of non zero PCRs
+	PCR0 := hex.EncodeToString(attestationPCRs.PCRs[0])
+	PCR1 := hex.EncodeToString(attestationPCRs.PCRs[1])
+	PCR2 := hex.EncodeToString(attestationPCRs.PCRs[2])
+	PCR8 := hex.EncodeToString(attestationPCRs.PCRs[8])
+
+	return attestation.PCRs{PCR0: PCR0, PCR1: PCR1, PCR2: PCR2, PCR8: PCR8}
+}
+
+// attestCert attests the certificate against the expected PCRs.
+func attestCert(certificate *x509.Certificate, expectedPCRs []attestation.PCRs, attestationDoc []byte) (bool, error) {
+	res, err := nitrite.Verify(attestationDoc, nitrite.VerifyOptions{CurrentTime: time.Now()})
+	if err != nil {
+		return false, fmt.Errorf("unable to verify certificate %w", err)
+	}
+
+	if !res.SignatureOK {
+		return false, ErrUnVerifiedSignature
+	}
+
+	if verified := verifyPCRs(expectedPCRs, *res.Document); !verified {
+		return verified, nil
+	}
+
+	// Validate that the cert public key is embedded in the attestation doc
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(certificate.PublicKey)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal publicKey to bytes %w", err)
+	}
+
+	return bytes.Equal(pubKeyBytes, res.Document.UserData), nil
+}
+
+// verifyPCRs verifies the expected PCRs against the attestation document.
+func verifyPCRs(expectedPCRs []attestation.PCRs, attestationDocument nitrite.Document) bool {
+	attestationPCRs := mapAttestationPCRs(attestationDocument)
+	for _, expectedPCR := range expectedPCRs {
+		if expectedPCR.Equal(attestationPCRs) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// filterEmptyPCRs removes empty PCR sets from the given slice.
+func filterEmptyPCRs(expectedPCRs []attestation.PCRs) []attestation.PCRs {
+	var ret []attestation.PCRs
+
+	for _, pcrs := range expectedPCRs {
+		if !pcrs.IsEmpty() {
+			ret = append(ret, pcrs)
+		}
+	}
+
+	return ret
+}
+
+// dialTimeout specifies the timeout duration for dialing a remote host.
+var dialTimeout = 5 * time.Second
+
+// createDial returns a custom dial function that performs attestation on the connection.
+func (c *Client) createDial(
+	tlsConfig *tls.Config,
+	cache *internalAttestation.Cache,
+	pcrManager internalAttestation.PCRManager,
+) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if network != "tcp" {
+			return nil, ErrUnsupportedNetworkType
+		}
+		// Create a TCP connection
+		conn, err := net.DialTimeout(network, addr, dialTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("error creating cage dial %w", err)
+		}
+
+		expectedPCRs := pcrManager.Get()
+
+		// Perform TLS handshake with custom configuration
+		tlsConn := tls.Client(conn, tlsConfig)
+
+		err = tlsConn.Handshake()
+		if err != nil {
+			return nil, fmt.Errorf("error connecting to cage %w", err)
+		}
+
+		cert := tlsConn.ConnectionState().PeerCertificates[0]
+		doc := cache.Get()
+
+		attestationDoc, err := attestCert(cert, *expectedPCRs, doc)
+		if err != nil {
+			// Get new attestation doc in case of Cage deployment
+			cache.LoadDoc(ctx)
+
+			_, err := attestCert(cert, *expectedPCRs, doc)
+			if err != nil {
+				return nil, fmt.Errorf("error attesting Connection %w", err)
+			}
+		}
+
+		if !attestationDoc {
+			return nil, ErrAttestionFailure
+		}
+
+		return tlsConn, nil
+	}
+}

--- a/attestation/pcrs.go
+++ b/attestation/pcrs.go
@@ -35,3 +35,9 @@ func (p *PCRs) Equal(pcrs PCRs) bool {
 func (p *PCRs) IsEmpty() bool {
 	return p.PCR0 == "" && p.PCR1 == "" && p.PCR2 == "" && p.PCR8 == ""
 }
+
+func BuildStaticPcrProvider(pcrs []PCRs) func() ([]PCRs, error) {
+	return func() ([]PCRs, error) {
+		return pcrs, nil
+	}
+}

--- a/cage.go
+++ b/cage.go
@@ -82,7 +82,7 @@ func (c *Client) CagesClient(cageHostname string, pcrs []attestation.PCRs) (*htt
 func (c *Client) CagesClientWithProvider(cageHostname string,
 	pcrsProvider func() ([]attestation.PCRs, error),
 ) (*http.Client, error) {
-	pcrManager := internalAttestation.NewPollingPCRManager(c.Config.AttestationPollingInterval, pcrsProvider)
+	pcrManager := internalAttestation.NewPollingPCRManager(c.Config.CagesPollingInterval, pcrsProvider)
 
 	cagesClient, err := c.createCagesClient(pcrManager, cageHostname)
 	if err != nil {
@@ -101,7 +101,7 @@ func (c *Client) createCagesClient(pcrManager internalAttestation.PCRManager,
 		return nil, ErrNoPCRs
 	}
 
-	cache, err := internalAttestation.NewAttestationCache(cageHostname, c.Config.AttestationPollingInterval)
+	cache, err := internalAttestation.NewAttestationCache(cageHostname, c.Config.CagesPollingInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/cage.go
+++ b/cage.go
@@ -1,36 +1,12 @@
 package evervault
 
 import (
-	"bytes"
-	"context"
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/hex"
-	"fmt"
-	"net"
 	"net/http"
-	"time"
 
 	"github.com/evervault/evervault-go/attestation"
 	internalAttestation "github.com/evervault/evervault-go/internal/attestation"
-	"github.com/hf/nitrite"
 )
-
-// cageDialTimeout specifies the timeout duration for dialing a cage.
-var cageDialTimeout = 5 * time.Second
-
-// filterEmptyPCRs removes empty PCR sets from the given slice.
-func filterEmptyPCRs(expectedPCRs []attestation.PCRs) []attestation.PCRs {
-	var ret []attestation.PCRs
-
-	for _, pcrs := range expectedPCRs {
-		if !pcrs.IsEmpty() {
-			ret = append(ret, pcrs)
-		}
-	}
-
-	return ret
-}
 
 // Will return a http.Client that is connected to a specified cage hostname with a fully attested client.
 // The Client will attest the connection every time it makes a HTTP request and will return an error on request if it
@@ -60,6 +36,8 @@ func filterEmptyPCRs(expectedPCRs []attestation.PCRs) []attestation.PCRs {
 //	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 //
 //	resp, err := cageClient.Do(req)
+//
+// Deprecated: Use EnclaveClient instead.
 func (c *Client) CagesClient(cageHostname string, pcrs []attestation.PCRs) (*http.Client, error) {
 	pcrManager := internalAttestation.NewStaticPCRManager(pcrs)
 
@@ -99,6 +77,8 @@ func (c *Client) CagesClient(cageHostname string, pcrs []attestation.PCRs) (*htt
 //	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 //
 //	resp, err := cageClient.Do(req)
+//
+// Deprecated: Use EnclaveClientWithProvider instead.
 func (c *Client) CagesClientWithProvider(cageHostname string,
 	pcrsProvider func() ([]attestation.PCRs, error),
 ) (*http.Client, error) {
@@ -147,94 +127,4 @@ func (c *Client) cagesClient(cageHostname string,
 	}
 
 	return &http.Client{Transport: transport}
-}
-
-// verifyPCRs verifies the expected PCRs against the attestation document.
-func verifyPCRs(expectedPCRs []attestation.PCRs, attestationDocument nitrite.Document) bool {
-	attestationPCRs := mapAttestationPCRs(attestationDocument)
-	for _, expectedPCR := range expectedPCRs {
-		if expectedPCR.Equal(attestationPCRs) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// mapAttestationPCRs maps the attestation document's PCRs to a PCRs struct.
-func mapAttestationPCRs(attestationPCRs nitrite.Document) attestation.PCRs {
-	// We verify a subset of non zero PCRs
-	PCR0 := hex.EncodeToString(attestationPCRs.PCRs[0])
-	PCR1 := hex.EncodeToString(attestationPCRs.PCRs[1])
-	PCR2 := hex.EncodeToString(attestationPCRs.PCRs[2])
-	PCR8 := hex.EncodeToString(attestationPCRs.PCRs[8])
-
-	return attestation.PCRs{PCR0: PCR0, PCR1: PCR1, PCR2: PCR2, PCR8: PCR8}
-}
-
-// createDial returns a custom dial function that performs attestation on the connection.
-func (c *Client) createDial(tlsConfig *tls.Config, cache *internalAttestation.Cache,
-	pcrManager internalAttestation.PCRManager) func(ctx context.Context,
-	network, addr string) (net.Conn, error) {
-	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		// Create a TCP connection
-		conn, err := net.DialTimeout(network, addr, cageDialTimeout)
-		if err != nil {
-			return nil, fmt.Errorf("error creating cage dial %w", err)
-		}
-
-		expectedPCRs := pcrManager.Get()
-
-		// Perform TLS handshake with custom configuration
-		tlsConn := tls.Client(conn, tlsConfig)
-
-		err = tlsConn.Handshake()
-		if err != nil {
-			return nil, fmt.Errorf("error connecting to cage %w", err)
-		}
-
-		cert := tlsConn.ConnectionState().PeerCertificates[0]
-		doc := cache.Get()
-
-		attestationDoc, err := attestCert(cert, *expectedPCRs, doc)
-		if err != nil {
-			// Get new attestation doc in case of Cage deployment
-			cache.LoadDoc(ctx)
-
-			_, err := attestCert(cert, *expectedPCRs, doc)
-			if err != nil {
-				return nil, fmt.Errorf("error attesting Connection %w", err)
-			}
-		}
-
-		if !attestationDoc {
-			return nil, ErrAttestionFailure
-		}
-
-		return tlsConn, nil
-	}
-}
-
-// attestCert attests the certificate against the expected PCRs.
-func attestCert(certificate *x509.Certificate, expectedPCRs []attestation.PCRs, attestationDoc []byte) (bool, error) {
-	res, err := nitrite.Verify(attestationDoc, nitrite.VerifyOptions{CurrentTime: time.Now()})
-	if err != nil {
-		return false, fmt.Errorf("unable to verify certificate %w", err)
-	}
-
-	if !res.SignatureOK {
-		return false, ErrUnVerifiedSignature
-	}
-
-	if verified := verifyPCRs(expectedPCRs, *res.Document); !verified {
-		return verified, nil
-	}
-
-	// Validate that the cert public key is embedded in the attestation doc
-	pubKeyBytes, err := x509.MarshalPKIXPublicKey(certificate.PublicKey)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal publicKey to bytes %w", err)
-	}
-
-	return bytes.Equal(pubKeyBytes, res.Document.UserData), nil
 }

--- a/cage.go
+++ b/cage.go
@@ -82,7 +82,7 @@ func (c *Client) CagesClient(cageHostname string, pcrs []attestation.PCRs) (*htt
 func (c *Client) CagesClientWithProvider(cageHostname string,
 	pcrsProvider func() ([]attestation.PCRs, error),
 ) (*http.Client, error) {
-	pcrManager := internalAttestation.NewPollingPCRManager(c.Config.CagesPollingInterval, pcrsProvider)
+	pcrManager := internalAttestation.NewPollingPCRManager(c.Config.AttestationPollingInterval, pcrsProvider)
 
 	cagesClient, err := c.createCagesClient(pcrManager, cageHostname)
 	if err != nil {
@@ -101,7 +101,7 @@ func (c *Client) createCagesClient(pcrManager internalAttestation.PCRManager,
 		return nil, ErrNoPCRs
 	}
 
-	cache, err := internalAttestation.NewAttestationCache(cageHostname, c.Config.CagesPollingInterval)
+	cache, err := internalAttestation.NewAttestationCache(cageHostname, c.Config.AttestationPollingInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/cage_test.go
+++ b/cage_test.go
@@ -42,7 +42,7 @@ func makeTestClient(t *testing.T) (*evervault.Client, error) {
 		t.Skip("Skipping testing when no app uuid provided")
 	}
 
-	apiKey := os.Getenv("EV_API_KEY")
+	apiKey := os.Getenv("EV_ENCLAVE_API_KEY")
 	if apiKey == "" {
 		t.Skip("Skipping testing when no API key provided")
 	}
@@ -63,7 +63,7 @@ func buildCageRequest(t *testing.T, testCage string) *http.Request {
 	}
 
 	req.Close = true
-	req.Header.Set("API-KEY", os.Getenv("EV_API_KEY"))
+	req.Header.Set("API-KEY", os.Getenv("EV_ENCLAVE_API_KEY"))
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	return req

--- a/config.go
+++ b/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	EvervaultCagesCaURL  string        // URL for the Evervault Cages CA.
 	RelayURL             string        // URL for the Evervault Relay.
 	EvAPIURL             string        // URL for the Evervault API.
+	CagesPollingInterval time.Duration // Polling interval for obtaining fresh attestation doc in seconds
 	AttestationPollingInterval time.Duration // Polling interval for obtaining fresh attestation doc in seconds
 }
 
@@ -23,6 +24,7 @@ func MakeConfig() Config {
 		EvervaultCagesCaURL:  getEnvOrDefault("EV_CAGES_CA_URL", "https://cages-ca.evervault.com/cages-ca.crt"),
 		RelayURL:             getEnvOrDefault("EV_RELAY_URL", "https://relay.evervault.com"),
 		EvAPIURL:             getEnvOrDefault("EV_API_URL", "https://api.evervault.com"),
+		CagesPollingInterval: getAttestationPollingInterval(),
 		AttestationPollingInterval: getAttestationPollingInterval(),
 	}
 }

--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	EvervaultCagesCaURL  string        // URL for the Evervault Cages CA.
 	RelayURL             string        // URL for the Evervault Relay.
 	EvAPIURL             string        // URL for the Evervault API.
-	CagesPollingInterval time.Duration // Polling interval for obtaining fresh attestation doc in seconds
+	AttestationPollingInterval time.Duration // Polling interval for obtaining fresh attestation doc in seconds
 }
 
 // MakeConfig loads the Evervault client configuration from environment variables.
@@ -23,17 +23,22 @@ func MakeConfig() Config {
 		EvervaultCagesCaURL:  getEnvOrDefault("EV_CAGES_CA_URL", "https://cages-ca.evervault.com/cages-ca.crt"),
 		RelayURL:             getEnvOrDefault("EV_RELAY_URL", "https://relay.evervault.com"),
 		EvAPIURL:             getEnvOrDefault("EV_API_URL", "https://api.evervault.com"),
-		CagesPollingInterval: getPollingInterval(),
+		AttestationPollingInterval: getAttestationPollingInterval(),
 	}
 }
 
-func getPollingInterval() time.Duration {
+func getAttestationPollingInterval() time.Duration {
 	const defaultPollingInterval = 2700
 
-	intervalStr := getEnvOrDefault("EV_CAGES_POLLING_INTERVAL", "7200")
+	intervalStr := os.Getenv("EV_ATTESTATION_POLLING_INTERVAL")
+	
+	if intervalStr == "" {
+		intervalStr = getEnvOrDefault("EV_CAGES_POLLING_INTERVAL", "7200")
+	}
+
 	interval, err := strconv.ParseInt(intervalStr, 10, 64)
 
-	if err == nil {
+	if err != nil {
 		return defaultPollingInterval
 	}
 

--- a/enclave.go
+++ b/enclave.go
@@ -54,7 +54,7 @@ func (c *Client) EnclaveClient(enclaveHostname string, pcrs []attestation.PCRs) 
 // The Client will attest the connection every time it makes a HTTP request and will return an error on request if it
 // fails attestation
 //
-//	enclaveURL = "<ENCLAVE_NAME>.<APP_UUID>.cages.evervault.com"
+//	enclaveURL = "<ENCLAVE_NAME>.<APP_UUID>.enclave.evervault.com"
 //	func GetPCRs() ([]attestation.PCRs, error) {
 //		// logic to get PCRs
 //		return pcrs, nil
@@ -132,7 +132,7 @@ func (c *Client) EnclaveTCPConnectionWithProvider(
 	enclaveHostname string,
 	pcrsProvider func() ([]attestation.PCRs, error),
 ) (func(ctx context.Context, network, addr string) (net.Conn, error), error) {
-	pcrManager := internalAttestation.NewPollingPCRManager(c.Config.CagesPollingInterval, pcrsProvider)
+	pcrManager := internalAttestation.NewPollingPCRManager(c.Config.AttestationPollingInterval, pcrsProvider)
 
 	expectedPcrs := pcrManager.Get()
 
@@ -140,7 +140,7 @@ func (c *Client) EnclaveTCPConnectionWithProvider(
 		return nil, ErrNoPCRs
 	}
 
-	cache, err := internalAttestation.NewAttestationCache(enclaveHostname, c.Config.CagesPollingInterval)
+	cache, err := internalAttestation.NewAttestationCache(enclaveHostname, c.Config.AttestationPollingInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/enclave.go
+++ b/enclave.go
@@ -1,0 +1,155 @@
+package evervault
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+
+	"github.com/evervault/evervault-go/attestation"
+	internalAttestation "github.com/evervault/evervault-go/internal/attestation"
+)
+
+// Will return a http.Client that is connected to a specified enclave hostname with a fully attested client.
+// The Client will attest the connection every time it makes a HTTP request and will return an error on request if it
+// fails attestation
+//
+//	enclaveURL = "<ENCLAVE_NAME>.<APP_UUID>.enclave.evervault.com"
+//	expectedPCRs := evervault.PCRs{
+//		PCR0: "f039c31c536749ac6b2a9344fcb36881dd1cf066ca44afcaf9369a9877e2d3c85fa738c427d502e01e35994da7458e2d",
+//		PCR1: "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
+//		PCR2: "71c478711438fe252fbd9b1da56218bea5d630da55aa56431257df77bd42f65a434601bf53be9a1901fcd61680e425c7",
+//		PCR8: "1650274b27bf44fba6f1779602399763af9e4567927d771b1b37aeb1ac502c84fbd6a7ab7b05600656a257247529fbb8",
+//	}
+//
+//	enclaveClient, err := evClient.EnclaveClient(enclaveURL, []evervault.PCRs{expectedPCRs})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	payload, err := json.Marshal(fmt.Sprintf(`{"encrypted": "%s"}`, encrypted))
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("https://%s/", enclaveURL), bytes.NewBuffer(payload))
+//	req.Close = true
+//	req.Header.Set("API-KEY", "<API_KEY>")
+//	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+//
+//	resp, err := enclaveClient.Do(req)
+func (c *Client) EnclaveClient(enclaveHostname string, pcrs []attestation.PCRs) (*http.Client, error) {
+	provider := attestation.BuildStaticPcrProvider(pcrs)
+
+	client, err := c.EnclaveClientWithProvider(enclaveHostname, provider)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+// Will return an http.Client that is connected to a specified enclave hostname with a fully attested client.
+// Specify a callback to be polled periodically to pick up the latest PCRs to attest with.
+// The Client will attest the connection every time it makes a HTTP request and will return an error on request if it
+// fails attestation
+//
+//	enclaveURL = "<ENCLAVE_NAME>.<APP_UUID>.cages.evervault.com"
+//	func GetPCRs() ([]attestation.PCRs, error) {
+//		// logic to get PCRs
+//		return pcrs, nil
+//	}
+//
+//
+//	enclaveClient, err := evClient.EnclaveClientWithProvider(enclaveURL, GetPCRs)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	payload, err := json.Marshal(fmt.Sprintf(`{"encrypted": "%s"}`, encrypted))
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("https://%s/", enclaveURL), bytes.NewBuffer(payload))
+//	req.Close = true
+//	req.Header.Set("API-KEY", "<API_KEY>")
+//	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+//
+//	resp, err := enclaveClient.Do(req)
+func (c *Client) EnclaveClientWithProvider(
+	enclaveHostname string,
+	pcrsProvider func() ([]attestation.PCRs, error),
+) (*http.Client, error) {
+	customDial, err := c.EnclaveTCPConnectionWithProvider(enclaveHostname, pcrsProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := &http.Transport{
+		DisableKeepAlives: true,
+		DialTLSContext:    customDial,
+	}
+
+	return &http.Client{Transport: transport}, nil
+}
+
+// Will return a http.Client that is connected to a specified enclave hostname with a fully attested client.
+// The Client will attest the connection every time it makes a HTTP request and will return an error on request if it
+// fails attestation
+//
+//		enclaveURL = "<ENCLAVE_NAME>.<APP_UUID>.enclave.evervault.com"
+//
+//		func GetPCRs() ([]attestation.PCRs, error) {
+//			// logic to get PCRs
+//			return evervault.PCRs{
+//				PCR0: "f039c31c536749ac6b2a9344fcb36881dd1cf066ca44afcaf9369a9877e2d3c85fa738c427d502e01e35994da7458e2d",
+//				PCR1: "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
+//				PCR2: "71c478711438fe252fbd9b1da56218bea5d630da55aa56431257df77bd42f65a434601bf53be9a1901fcd61680e425c7",
+//				PCR8: "1650274b27bf44fba6f1779602399763af9e4567927d771b1b37aeb1ac502c84fbd6a7ab7b05600656a257247529fbb8",
+//			}, nil
+//		}
+//
+//		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+//		defer cancel()
+//
+//		enclaveDial, err := evClient.EnclaveTCPConnectionWithProvider(enclaveURL, GetPCRs)
+//		if err != nil {
+//			log.Fatal(err)
+//		}
+//
+//		conn, err := enclaveDial(ctx, "tcp", enclaveURL)
+//		if err != nil {
+//			log.Fatal(err)
+//		}
+//
+//		defer conn.Close()
+//
+//		if _, err := conn.Write([]byte("Hello, World!")); err != nil {
+//	 	log.Fatal(err)
+//		}
+func (c *Client) EnclaveTCPConnectionWithProvider(
+	enclaveHostname string,
+	pcrsProvider func() ([]attestation.PCRs, error),
+) (func(ctx context.Context, network, addr string) (net.Conn, error), error) {
+	pcrManager := internalAttestation.NewPollingPCRManager(c.Config.CagesPollingInterval, pcrsProvider)
+
+	expectedPcrs := pcrManager.Get()
+
+	if len(filterEmptyPCRs(*expectedPcrs)) == 0 {
+		return nil, ErrNoPCRs
+	}
+
+	cache, err := internalAttestation.NewAttestationCache(enclaveHostname, c.Config.CagesPollingInterval)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: false,
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         enclaveHostname,
+	}
+
+	return c.createDial(tlsConfig, cache, pcrManager), nil
+}

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const enclave = "synthetic-cage.app-f5f084041a7e.enclave.evervault.com"
+const enclave = "synthetic-cage.app-f5f084041a7e.cage.evervault.com"
 
 type Echo struct {
 	ReqID string `json:"reqId"`

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -38,7 +38,7 @@ func makeTestClient(t *testing.T) (*evervault.Client, error) {
 		t.Skip("Skipping testing when no app uuid provided")
 	}
 
-	apiKey := os.Getenv("EV_API_KEY")
+	apiKey := os.Getenv("EV_ENCLAVE_API_KEY")
 	if apiKey == "" {
 		t.Skip("Skipping testing when no API key provided")
 	}
@@ -79,7 +79,7 @@ func buildEnclaveRequest(t *testing.T, testEnclave string) *http.Request {
 	}
 
 	req.Close = true
-	req.Header.Set("API-KEY", os.Getenv("EV_API_KEY"))
+	req.Header.Set("API-KEY", os.Getenv("EV_ENCLAVE_API_KEY"))
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	return req

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -1,0 +1,275 @@
+//go:build unit_test
+// +build unit_test
+
+package evervault_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/evervault/evervault-go"
+	"github.com/evervault/evervault-go/attestation"
+	"github.com/stretchr/testify/assert"
+)
+
+const enclave = "synthetic-cage.app-f5f084041a7e.enclave.evervault.com"
+
+type Echo struct {
+	ReqID string `json:"reqId"`
+	Body  Body   `json:"body"`
+}
+
+func buildEnclaveRequest(t *testing.T, testEnclave string) *http.Request {
+	t.Helper()
+
+	ctx := context.Background()
+	body := bytes.NewBufferString(`{"test": true}`)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://%s/echo", testEnclave), body)
+	if err != nil {
+		t.Fatal("Couldnt build enclave request: %w", err)
+		return nil
+	}
+
+	req.Close = true
+	req.Header.Set("API-KEY", os.Getenv("EV_API_KEY"))
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+
+	return req
+}
+
+func TestEnclaveClient(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	testClient, err := makeTestClient(t)
+	if err != nil {
+		t.Errorf("Error creating evervault client: %s", err)
+		return
+	}
+
+	expectedPCRs := attestation.PCRs{
+		PCR0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		PCR1: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		PCR2: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		PCR8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	client, err := testClient.EnclaveClient(cage, []attestation.PCRs{expectedPCRs})
+	if err != nil {
+		t.Errorf("Error creating enclave client: %s", err)
+		return
+	}
+
+	req := buildEnclaveRequest(t, cage)
+
+	t.Log("making request", cage)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Errorf("Error making request: %s", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	assert.Equal("200 OK", resp.Status)
+	assert.Contains(resp.Header, "X-Evervault-Cage-Ctx")
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("failed to read response body: %s", err)
+		return
+	}
+
+	var jsonResp Echo
+	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
+		t.Errorf("failed to unmarshal response body: %s", err)
+		return
+	}
+
+	assert.Equal(jsonResp.Body.Test, true)
+}
+
+func TestEnclavePartialPCR(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	testClient, err := makeTestClient(t)
+	if err != nil {
+		t.Errorf("Error creating evervault client: %s", err)
+		return
+	}
+
+	expectedPCRs := attestation.PCRs{
+		PCR8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	enclaveClient, err := testClient.EnclaveClient(cage, []attestation.PCRs{expectedPCRs})
+	if err != nil {
+		t.Errorf("Error creating enclave client: %s", err)
+		return
+	}
+
+	req := buildEnclaveRequest(t, cage)
+
+	t.Log("making request", cage)
+
+	resp, err := enclaveClient.Do(req)
+	if err != nil {
+		t.Errorf("Error making request: %s", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	assert.Equal("200 OK", resp.Status)
+	assert.Contains(resp.Header, "X-Evervault-Cage-Ctx")
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("failed to read response body: %s", err)
+		return
+	}
+
+	var jsonResp Echo
+	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
+		t.Errorf("failed to unmarshal response body: %s", err)
+		return
+	}
+
+	assert.Equal(jsonResp.Body.Test, true)
+}
+
+func TestEnclavePartialPCRProvider(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	testClient, err := makeTestClient(t)
+	if err != nil {
+		t.Errorf("Error creating evervault client: %s", err)
+		return
+	}
+
+	enclaveClient, err := testClient.EnclaveClientWithProvider(enclave, GetPCRData)
+	if err != nil {
+		t.Errorf("Error creating enclave client: %s", err)
+		return
+	}
+
+	req := buildEnclaveRequest(t, enclave)
+
+	t.Log("making request", enclave)
+
+	resp, err := enclaveClient.Do(req)
+	if err != nil {
+		t.Errorf("Error making request: %s", err)
+		return
+	}
+
+	defer resp.Body.Close()
+
+	assert.Equal("200 OK", resp.Status)
+	assert.Contains(resp.Header, "X-Evervault-Cage-Ctx")
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("failed to read response body: %s", err)
+		return
+	}
+
+	var jsonResp Echo
+	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
+		t.Errorf("failed to unmarshal response body: %s", err)
+		return
+	}
+
+	assert.Equal(jsonResp.Body.Test, true)
+}
+
+func TestEnclaveFailsOnPartialIncorrectPCRProvider(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	testClient, err := makeTestClient(t)
+	if err != nil {
+		t.Errorf("Error creating evervault client: %s", err)
+		return
+	}
+
+	enclaveClient, err := testClient.EnclaveClientWithProvider(enclave, GetInvalidPCRData)
+	if err != nil {
+		t.Errorf("Error creating enclave client: %s", err)
+		return
+	}
+
+	req := buildEnclaveRequest(t, enclave)
+
+	t.Log("making request", enclave)
+
+	resp, err := enclaveClient.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	assert.ErrorIs(err, evervault.ErrAttestionFailure)
+}
+
+func TestEnclaveFailsOnPartialIncorrectPCR(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	testClient, err := makeTestClient(t)
+	if err != nil {
+		t.Errorf("Error creating evervault client: %s", err)
+		return
+	}
+
+	expectedPCRs := attestation.PCRs{
+		PCR0: "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+		PCR8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	enclaveClient, err := testClient.EnclaveClient(enclave, []attestation.PCRs{expectedPCRs})
+	if err != nil {
+		t.Errorf("Error creating enclave client: %s", err)
+		return
+	}
+
+	req := buildEnclaveRequest(t, enclave)
+
+	t.Log("making request", enclave)
+
+	resp, err := enclaveClient.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	assert.ErrorIs(err, evervault.ErrAttestionFailure)
+}
+
+func TestEnclaveRequiresPCR(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+
+	testClient, err := makeTestClient(t)
+	if err != nil {
+		t.Errorf("Error creating evervault client: %s", err)
+		return
+	}
+
+	_, err = testClient.EnclaveClient(cage, []attestation.PCRs{})
+	assert.ErrorIs(err, evervault.ErrNoPCRs)
+}

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -25,47 +25,6 @@ type Echo struct {
 	Body  Body   `json:"body"`
 }
 
-type Body struct {
-	Test    bool   `json:"test"`
-	Message string `json:"message,omitempty"`
-}
-
-func makeTestClient(t *testing.T) (*evervault.Client, error) {
-	t.Helper()
-
-	appUUID := os.Getenv("EV_APP_UUID")
-	if appUUID == "" {
-		t.Skip("Skipping testing when no app uuid provided")
-	}
-
-	apiKey := os.Getenv("EV_ENCLAVE_API_KEY")
-	if apiKey == "" {
-		t.Skip("Skipping testing when no API key provided")
-	}
-
-	return evervault.MakeClient(appUUID, apiKey)
-}
-
-func GetPCRData() ([]attestation.PCRs, error) {
-	var pcrs []attestation.PCRs
-	expectedPCRs := attestation.PCRs{
-		PCR0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-		PCR8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-	}
-	pcrs = append(pcrs, expectedPCRs)
-	return pcrs, nil
-}
-
-func GetInvalidPCRData() ([]attestation.PCRs, error) {
-	var pcrs []attestation.PCRs
-	expectedPCRs := attestation.PCRs{
-		PCR0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-		PCR8: "INVALID00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-	}
-	pcrs = append(pcrs, expectedPCRs)
-	return pcrs, nil
-}
-
 func buildEnclaveRequest(t *testing.T, testEnclave string) *http.Request {
 	t.Helper()
 

--- a/error.go
+++ b/error.go
@@ -33,6 +33,10 @@ var ErrCryptoUnableToPerformEncryption = errors.New("unable to perform encryptio
 // ErrInvalidDataType is returned when an unsupported data type was specified for encryption.
 var ErrInvalidDataType = errors.New("Error: Invalid datatype")
 
+// ErrUnsupportedNetworkType is returned when an unsupported network type was supplied.
+// Only TCP is supported for Enclaves.
+var ErrUnsupportedNetworkType = errors.New("error: unsupported network type")
+
 func ExtractAPIError(resp []byte) error {
 	evervaultError := APIError{}
 	if err := json.Unmarshal(resp, &evervaultError); err != nil {


### PR DESCRIPTION
# Why

As we're preparing to release enclaves, we need to deprecate the old functions and introduce the new enclave alternatives.

# How

Add enclave module which also includes a TCP connection builder
