### PR TITLE
[ETR-2718] Add retry mechanism to attestation doc fetching

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -43,7 +43,7 @@ func Example() {
 	ctx := context.Background()
 	body := bytes.NewBuffer(payload)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.com/", body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://httpbin.org/post", body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -43,7 +43,7 @@ func Example() {
 	ctx := context.Background()
 	body := bytes.NewBuffer(payload)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://httpbin.org/post", body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://example.com/", body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/attestation/attestation_cache.go
+++ b/internal/attestation/attestation_cache.go
@@ -77,6 +77,7 @@ type CageDocResponse struct {
 
 func (c *Cache) getDoc(ctx context.Context) ([]byte, error) {
 	var lastErr error
+
 	backoff := initialBackoff
 
 	for retry := 0; retry < maxRetries; retry++ {
@@ -90,6 +91,7 @@ func (c *Cache) getDoc(ctx context.Context) ([]byte, error) {
 			}
 
 			lastErr = err
+			
 			if retry < maxRetries-1 {
 				log.Printf("Attempt %d failed, retrying in %v: %v", retry+1, backoff, err)
 

--- a/internal/attestation/attestation_cache.go
+++ b/internal/attestation/attestation_cache.go
@@ -22,7 +22,7 @@ type Cache struct {
 }
 
 const (
-	pollTimeout    = 10 * time.Second
+	pollTimeout    = 5 * time.Second
 	maxRetries     = 3
 	initialBackoff = 1 * time.Second
 	maxBackoff     = 5 * time.Second
@@ -38,7 +38,7 @@ func NewAttestationCache(cageDomain string, pollingInterval time.Duration) (*Cac
 		cageURL:  cageURL,
 		doc:      make([]byte, 0),
 		mutex:    sync.RWMutex{},
-		client:   http.Client{Timeout: pollTimeout},
+		client:   http.Client{Timeout: 10 * time.Second},
 		ticker:   time.NewTicker(pollingInterval),
 		stopPoll: make(chan bool),
 	}

--- a/internal/attestation/attestation_cache.go
+++ b/internal/attestation/attestation_cache.go
@@ -91,7 +91,7 @@ func (c *Cache) getDoc(ctx context.Context) ([]byte, error) {
 			}
 
 			lastErr = err
-			
+
 			if retry < maxRetries-1 {
 				log.Printf("Attempt %d failed, retrying in %v: %v", retry+1, backoff, err)
 

--- a/internal/attestation/attestation_cache.go
+++ b/internal/attestation/attestation_cache.go
@@ -21,7 +21,12 @@ type Cache struct {
 	stopPoll chan bool
 }
 
-const pollTimeout = 5 * time.Second
+const (
+	pollTimeout    = 10 * time.Second
+	maxRetries     = 3
+	initialBackoff = 1 * time.Second
+	maxBackoff     = 5 * time.Second
+)
 
 func NewAttestationCache(cageDomain string, pollingInterval time.Duration) (*Cache, error) {
 	cageURL, err := url.Parse(fmt.Sprintf("https://%s/.well-known/attestation", cageDomain))
@@ -33,7 +38,7 @@ func NewAttestationCache(cageDomain string, pollingInterval time.Duration) (*Cac
 		cageURL:  cageURL,
 		doc:      make([]byte, 0),
 		mutex:    sync.RWMutex{},
-		client:   http.Client{},
+		client:   http.Client{Timeout: pollTimeout},
 		ticker:   time.NewTicker(pollingInterval),
 		stopPoll: make(chan bool),
 	}
@@ -71,29 +76,62 @@ type CageDocResponse struct {
 }
 
 func (c *Cache) getDoc(ctx context.Context) ([]byte, error) {
+	var lastErr error
+	backoff := initialBackoff
+
+	for retry := 0; retry < maxRetries; retry++ {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("context cancelled while getting attestation doc: %w", ctx.Err())
+		default:
+			docBytes, err := c.tryGetDoc(ctx)
+			if err == nil {
+				return docBytes, nil
+			}
+
+			lastErr = err
+			if retry < maxRetries-1 {
+				log.Printf("Attempt %d failed, retrying in %v: %v", retry+1, backoff, err)
+
+				select {
+				case <-ctx.Done():
+					return nil, fmt.Errorf("context cancelled during retry backoff: %w", ctx.Err())
+				case <-time.After(backoff):
+				}
+
+				backoff *= 2
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("failed to get attesatation document after %d retries, last error: %w", maxRetries, lastErr)
+}
+
+func (c *Cache) tryGetDoc(ctx context.Context) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, c.cageURL.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not generate attestation doc request %w", err)
+		return nil, fmt.Errorf("could not generate attestation doc request: %w", err)
 	}
 
 	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("could not get attestation doc %w", err)
+		return nil, fmt.Errorf("could not get attestation doc: %w", err)
 	}
-
 	defer resp.Body.Close()
 
 	var response CageDocResponse
-
 	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("error decoding attestation doc json %w", err)
+		return nil, fmt.Errorf("error decoding attestation doc json: %w", err)
 	}
 
 	docBytes, err := base64.StdEncoding.DecodeString(response.AttestationDoc)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding attestation doc %w", err)
+		return nil, fmt.Errorf("error decoding attestation doc: %w", err)
 	}
 
 	return docBytes, nil

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -117,6 +117,10 @@ func EncryptValue(
 		return "", fmt.Errorf("unable to build metadata %w", err)
 	}
 
+	if len(metadata) > int(^uint16(0)) {
+		return "", fmt.Errorf("metadata length %d exceeds maximum uint16 value", len(metadata))
+	}
+
 	// Get the concatenated result as a byte slice
 	metadataOffset := make([]byte, metadataOffsetLength)
 	binary.LittleEndian.PutUint16(metadataOffset, uint16(len(metadata)))
@@ -191,8 +195,13 @@ func encodeEncryptionTimestamp(buffer *bytes.Buffer) error {
 		return fmt.Errorf("error building metadata %w", err)
 	}
 
+	unixTime := time.Now().Unix()
+	if unixTime < 0 || unixTime > int64(^uint32(0)) {
+		return fmt.Errorf("unix timestamp %d outside valid uint32 range", unixTime)
+	}
+
 	// Get the current time and convert it to Unix timestamp (seconds since Jan 1, 1970)
-	currentTime := uint32(time.Now().Unix())
+	currentTime := uint32(unixTime)
 
 	err = binary.Write(buffer, binary.BigEndian, currentTime)
 	if err != nil {

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -210,6 +210,7 @@ func encodeEncryptionTimestamp(buffer *bytes.Buffer) error {
 
 	currentTime := uint32(unixTime)
 	err = binary.Write(buffer, binary.BigEndian, currentTime)
+	
 	if err != nil {
 		return fmt.Errorf("error building metadata: %w", err)
 	}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -33,12 +32,6 @@ const (
 	encryptionOrigin                              = 0x09
 	defaultRoleNameLength                         = 0xa0
 	binaryRepresentationOfFourByteUnsignedInteger = 0xce
-	maxUint16                                     = 6553
-)
-
-var (
-	ErrMetadataLengthExceedsMaxUint16 = errors.New("metadata length exceeds maximum uint16 value")
-	ErrUnixTimestampOutOfRange        = errors.New("unix timestamp outside valid uint32 range")
 )
 
 // DeriveKDFAESKey derives an AES key using the given public key and shared ECDH secret.
@@ -124,13 +117,9 @@ func EncryptValue(
 		return "", fmt.Errorf("unable to build metadata %w", err)
 	}
 
-	if len(metadata) > maxUint16 {
-		return "", ErrMetadataLengthExceedsMaxUint16
-	}
-
 	// Get the concatenated result as a byte slice
 	metadataOffset := make([]byte, metadataOffsetLength)
-	//nolint:gosec // checked len(metadata) is within uint16 range
+	//nolint:gosec
 	binary.LittleEndian.PutUint16(metadataOffset, uint16(len(metadata)))
 
 	var buffer bytes.Buffer
@@ -203,16 +192,13 @@ func encodeEncryptionTimestamp(buffer *bytes.Buffer) error {
 		return fmt.Errorf("error building metadata %w", err)
 	}
 
-	unixTime := time.Now().Unix()
-	if unixTime < 0 || unixTime > int64(^uint32(0)) {
-		return ErrUnixTimestampOutOfRange
-	}
+	// Get the current time and convert it to Unix timestamp (seconds since Jan 1, 1970)
+	//nolint:gosec
+	currentTime := uint32(time.Now().Unix())
 
-	currentTime := uint32(unixTime)
 	err = binary.Write(buffer, binary.BigEndian, currentTime)
-	
 	if err != nil {
-		return fmt.Errorf("error building metadata: %w", err)
+		return fmt.Errorf("error building metadata %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
# Why

It only tries to fetch the AD once, we should implement retries with backoff

# How
This pull request to `internal/attestation/attestation_cache.go` includes changes to improve the reliability and robustness of the attestation document retrieval process by implementing a retry mechanism with exponential backoff. The most important changes include defining new constants for timeout and backoff settings, updating the HTTP client timeout, and adding a retry loop to handle transient errors.

Enhancements to attestation document retrieval:

* Defined new constants for `pollTimeout`, `maxRetries`, `initialBackoff`, and `maxBackoff` to manage retry logic and backoff intervals. (`internal/attestation/attestation_cache.go`)
* Updated the HTTP client in the `NewAttestationCache` function to use the `pollTimeout` for its timeout setting. (`internal/attestation/attestation_cache.go`)
* Added a retry loop with exponential backoff in the `getDoc` method to handle transient errors and improve reliability. (`internal/attestation/attestation_cache.go`)
* Created a new `tryGetDoc` method to encapsulate the logic for making a single attempt to retrieve the attestation document, which is called within the retry loop. (`internal/attestation/attestation_cache.go`)
* Enhanced error messages in `tryGetDoc` to include more context for easier debugging. (`internal/attestation/attestation_cache.go`)
