### PR TITLE
Remove log line from latest version

### DIFF
--- a/.changeset/fuzzy-chefs-scream.md
+++ b/.changeset/fuzzy-chefs-scream.md
@@ -1,0 +1,5 @@
+---
+"evervault-go": patch
+---
+
+Remove log line from Attestation Document caching

--- a/internal/attestation/attestation_cache.go
+++ b/internal/attestation/attestation_cache.go
@@ -134,7 +134,6 @@ func (c *Cache) LoadDoc(ctx context.Context) {
 		return
 	}
 
-	log.Println("Evervault Attestation Document Cache: Document loaded")
 	c.Set(docBytes)
 }
 


### PR DESCRIPTION
# Why

No need for log on happy path.

# How

Remove log for when attestation doc has been cached.
