### PR TITLE
Remove bloat in tests checking for returned errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
           go-version: ${{ matrix.go }}
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1
           args: --timeout=5m
       - name: Test
         env:

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,22 +1,6 @@
-[output]
-# Sort results by: filepath, line and column.
-sort-results = true
+version = "2"
 
 [linters]
-presets = [
-  "bugs",
-  "comment",
-  "complexity",
-  "error",
-  "format",
-  "import",
-  "metalinter",
-  "module",
-  "performance",
-  "style",
-  "test",
-  "unused",
-]
 disable = [
   "exhaustruct",
   "gochecknoglobals",
@@ -25,47 +9,34 @@ disable = [
 [issues]
 fix = true
 
-[severity]
-case-sensitive = true
-
-[linters-settings.errcheck]
+[linters.settings.errcheck]
 # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
 check-type-assertions = true
 # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
 check-blank = true
 
-[linters-settings.exhaustive]
+[linters.settings.exhaustive]
 check = ["switch", "map"]
 default-signifies-exhaustive = true
 
-[linters-settings.govet]
-check-shadowing = true
+[linters.settings.govet]
+enable = ["shadow"]
 
-[linters-settings.grouper]
+[linters.settings.grouper]
 const-require-single-const = true
 import-require-single-import = true
 
-[linters-settings.maligned]
-# Print struct with more effective memory layout
-suggest-new = true
-
-[linters-settings.varcheck]
-exported-fields = true
-
-[linters-settings.gofumpt]
-module-path = "github.com/evervault/evervault-go"
-
-[linters-settings.depguard.rules.main]
+[linters.settings.depguard.rules.main]
 allow = ["$gostd", "github.com/evervault/evervault-go", "github.com/hf/nitrite","github.com/stretchr/testify/assert"]
 
-[linters-settings.nlreturn]
+[linters.settings.nlreturn]
 block-size = 3
 
-[linter-settings.wsl]
+[linters.settings.wsl]
 force-err-cuddling = true
 
-[linters-settings.varnamelen]
+[linters.settings.varnamelen]
 ignore-names = ["ok", "err", "iv"]
 
-[linters-settings.wrapcheck]
-ignorePackageGlobs = ["github.com/evervault/*"]
+[linters.settings.wrapcheck]
+ignore-package-globs = ["github.com/evervault/*"]

--- a/cage_test.go
+++ b/cage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evervault/evervault-go"
 	"github.com/evervault/evervault-go/attestation"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const cage = "synthetic-cage.app-f5f084041a7e.cage.evervault.com"
@@ -57,10 +58,7 @@ func buildCageRequest(t *testing.T, testCage string) *http.Request {
 	body := bytes.NewBufferString(`{"test": true}`)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://%s/echo", testCage), body)
-	if err != nil {
-		t.Fatal("Couldnt build cage request: %w", err)
-		return nil
-	}
+	require.NoError(t, err)
 
 	req.Close = true
 	req.Header.Set("API-KEY", os.Getenv("EV_ENCLAVE_API_KEY"))
@@ -75,10 +73,7 @@ func TestCageClient(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	expectedPCRs := attestation.PCRs{
 		PCR0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -88,20 +83,14 @@ func TestCageClient(t *testing.T) {
 	}
 
 	cageClient, err := testClient.CagesClient(cage, []attestation.PCRs{expectedPCRs})
-	if err != nil {
-		t.Errorf("Error creating cage client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildCageRequest(t, cage)
 
 	t.Log("making request", cage)
 
 	resp, err := cageClient.Do(req)
-	if err != nil {
-		t.Errorf("Error making request: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
@@ -109,10 +98,7 @@ func TestCageClient(t *testing.T) {
 	assert.Contains(resp.Header, "X-Evervault-Ctx")
 
 	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("failed to read response body: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	var jsonResp CageEcho
 	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
@@ -129,30 +115,21 @@ func TestCagePartialPCR(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	expectedPCRs := attestation.PCRs{
 		PCR8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 	}
 
 	cageClient, err := testClient.CagesClient(cage, []attestation.PCRs{expectedPCRs})
-	if err != nil {
-		t.Errorf("Error creating cage client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildCageRequest(t, cage)
 
 	t.Log("making request", cage)
 
 	resp, err := cageClient.Do(req)
-	if err != nil {
-		t.Errorf("Error making request: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
@@ -160,16 +137,11 @@ func TestCagePartialPCR(t *testing.T) {
 	assert.Contains(resp.Header, "X-Evervault-Ctx")
 
 	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("failed to read response body: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	var jsonResp CageEcho
-	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
-		t.Errorf("failed to unmarshal response body: %s", err)
-		return
-	}
+	err = json.Unmarshal(respBody, &jsonResp)
+	require.NoError(t, err)
 
 	assert.Equal(jsonResp.Body.Test, true)
 }
@@ -200,26 +172,17 @@ func TestCagePartialPCRProvider(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	cageClient, err := testClient.CagesClientWithProvider(cage, GetPCRData)
-	if err != nil {
-		t.Errorf("Error creating cage client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildCageRequest(t, cage)
 
 	t.Log("making request", cage)
 
 	resp, err := cageClient.Do(req)
-	if err != nil {
-		t.Errorf("Error making request: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
@@ -227,16 +190,11 @@ func TestCagePartialPCRProvider(t *testing.T) {
 	assert.Contains(resp.Header, "X-Evervault-Ctx")
 
 	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("failed to read response body: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	var jsonResp CageEcho
-	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
-		t.Errorf("failed to unmarshal response body: %s", err)
-		return
-	}
+	err = json.Unmarshal(respBody, &jsonResp)
+	require.NoError(t, err)
 
 	assert.Equal(jsonResp.Body.Test, true)
 }
@@ -247,16 +205,10 @@ func TestCageFailsOnPartialIncorrectPCRProvider(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	cageClient, err := testClient.CagesClientWithProvider(cage, GetInvalidPCRData)
-	if err != nil {
-		t.Errorf("Error creating cage client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildCageRequest(t, cage)
 
@@ -276,10 +228,7 @@ func TestCageFailsOnPartialIncorrectPCR(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	expectedPCRs := attestation.PCRs{
 		PCR0: "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
@@ -287,10 +236,7 @@ func TestCageFailsOnPartialIncorrectPCR(t *testing.T) {
 	}
 
 	cageClient, err := testClient.CagesClient(cage, []attestation.PCRs{expectedPCRs})
-	if err != nil {
-		t.Errorf("Error creating cage client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildCageRequest(t, cage)
 
@@ -310,10 +256,7 @@ func TestCageRequiresPCR(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = testClient.CagesClient(cage, []attestation.PCRs{})
 	assert.ErrorIs(err, evervault.ErrNoPCRs)

--- a/client.go
+++ b/client.go
@@ -180,6 +180,7 @@ func (c *Client) makeRequest(url, method string, body []byte, useBasicAuth bool)
 		return clientResponse{}, fmt.Errorf("error making request %w", err)
 	}
 
+	//nolint:errcheck
 	defer resp.Body.Close()
 
 	statusCode := resp.StatusCode

--- a/e2e/encrypt_e2e_test.go
+++ b/e2e/encrypt_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/evervault/evervault-go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestE2EEncryptString(t *testing.T) {
@@ -18,16 +19,10 @@ func TestE2EEncryptString(t *testing.T) {
 	payload := "hello world"
 
 	encrypted, err := client.EncryptString(payload)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptString(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %s %s", payload, decrypted)
@@ -49,10 +44,7 @@ func TestE2EEncryptStringWithPermittedRole(t *testing.T) {
 	}
 
 	decrypted, err := client.DecryptString(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %s %s", payload, decrypted)
@@ -68,16 +60,10 @@ func TestE2EEncryptStringWithDeniedRole(t *testing.T) {
 	payload := "hello world"
 
 	encrypted, err := client.EncryptStringWithDataRole(payload, "deny-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = client.DecryptString(encrypted)
-	if err == nil {
-		t.Errorf("expected error decrypting data")
-		return
-	}
+	require.Error(t, err)
 }
 
 func TestE2EEncryptBoolTrue(t *testing.T) {
@@ -88,16 +74,10 @@ func TestE2EEncryptBoolTrue(t *testing.T) {
 	payload := true
 
 	encrypted, err := client.EncryptBool(payload)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptBool(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
@@ -113,16 +93,10 @@ func TestE2EEncryptBoolTrueWithPermittedRole(t *testing.T) {
 	payload := true
 
 	encrypted, err := client.EncryptBoolWithDataRole(payload, "permit-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptBool(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
@@ -138,16 +112,10 @@ func TestE2EEncryptBoolTrueWithDeniedRole(t *testing.T) {
 	payload := true
 
 	encrypted, err := client.EncryptBoolWithDataRole(payload, "deny-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = client.DecryptBool(encrypted)
-	if err == nil {
-		t.Errorf("expected error decrypting data")
-		return
-	}
+	require.Error(t, err)
 }
 
 func TestE2EEncryptBoolFalse(t *testing.T) {
@@ -158,16 +126,10 @@ func TestE2EEncryptBoolFalse(t *testing.T) {
 	payload := false
 
 	encrypted, err := client.EncryptBool(payload)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptBool(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
@@ -183,16 +145,10 @@ func TestE2EEncryptBoolFalseWithPermittedRole(t *testing.T) {
 	payload := false
 
 	encrypted, err := client.EncryptBoolWithDataRole(payload, "permit-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptBool(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
@@ -208,16 +164,10 @@ func TestE2EEncryptBoolFalseWithDeniedRole(t *testing.T) {
 	payload := false
 
 	encrypted, err := client.EncryptBoolWithDataRole(payload, "deny-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = client.DecryptBool(encrypted)
-	if err == nil {
-		t.Errorf("expected error decrypting data")
-		return
-	}
+	require.Error(t, err)
 }
 
 func TestE2EEncryptInt(t *testing.T) {
@@ -228,16 +178,10 @@ func TestE2EEncryptInt(t *testing.T) {
 	payload := 1
 
 	encrypted, err := client.EncryptInt(payload)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptInt(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %d %d", payload, decrypted)
@@ -253,16 +197,10 @@ func TestE2EEncryptIntWithPermittedRole(t *testing.T) {
 	payload := 1
 
 	encrypted, err := client.EncryptIntWithDataRole(payload, "permit-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptInt(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %d %d", payload, decrypted)
@@ -278,16 +216,10 @@ func TestE2EEncryptIntWithDeniedRole(t *testing.T) {
 	payload := 1
 
 	encrypted, err := client.EncryptIntWithDataRole(payload, "deny-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = client.DecryptInt(encrypted)
-	if err == nil {
-		t.Errorf("expected error decrypting data")
-		return
-	}
+	require.Error(t, err)
 }
 
 func TestE2EEncryptFloat(t *testing.T) {
@@ -298,16 +230,10 @@ func TestE2EEncryptFloat(t *testing.T) {
 	payload := 1.5
 
 	encrypted, err := client.EncryptFloat64(payload)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptFloat64(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %f %f", payload, decrypted)
@@ -329,10 +255,7 @@ func TestE2EEncryptFloatWithPermittedRole(t *testing.T) {
 	}
 
 	decrypted, err := client.DecryptFloat64(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if payload != decrypted {
 		t.Errorf("decrypted data does not match the original %f %f", payload, decrypted)
@@ -347,16 +270,10 @@ func TestE2EEncryptFloatWithDeniedRole(t *testing.T) {
 	payload := 1.5
 
 	encrypted, err := client.EncryptFloat64WithDataRole(payload, "deny-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = client.DecryptFloat64(encrypted)
-	if err == nil {
-		t.Errorf("expected error decrypting data")
-		return
-	}
+	require.Error(t, err)
 }
 
 func TestE2EEncryptBytes(t *testing.T) {
@@ -367,16 +284,10 @@ func TestE2EEncryptBytes(t *testing.T) {
 	payload := []byte{97, 98, 99, 100, 101, 102}
 
 	encrypted, err := client.EncryptByteArray(payload)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptByteArray(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if string(payload) != string(decrypted) {
 		t.Errorf("decrypted data does not match the original %s %s", string(payload), string(decrypted))
@@ -392,16 +303,10 @@ func TestE2EEncryptBytesWithPermittedRole(t *testing.T) {
 	payload := []byte{97, 98, 99, 100, 101, 102}
 
 	encrypted, err := client.EncryptByteArrayWithDataRole(payload, "permit-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptByteArray(encrypted)
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if string(payload) != string(decrypted) {
 		t.Errorf("decrypted data does not match the original %s %s", string(payload), string(decrypted))
@@ -417,16 +322,10 @@ func TestE2EEncryptBytesWithDeniedRole(t *testing.T) {
 	payload := []byte{97, 98, 99, 100, 101, 102}
 
 	encrypted, err := client.EncryptByteArrayWithDataRole(payload, "deny-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = client.DecryptByteArray(encrypted)
-	if err == nil {
-		t.Errorf("expected error decrypting data")
-		return
-	}
+	require.Error(t, err)
 }
 
 type MyStruct struct {
@@ -445,9 +344,7 @@ func GetClient(t *testing.T) *evervault.Client {
 	apiKey := os.Getenv("EV_API_KEY")
 
 	client, err := evervault.MakeClient(appUUID, apiKey)
-	if err != nil {
-		t.Fail()
-	}
+	require.NoError(t, err)
 
 	return client
 }

--- a/e2e/function_e2e_test.go
+++ b/e2e/function_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evervault/evervault-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var functionName string = os.Getenv("EV_FUNCTION_NAME")
@@ -22,24 +23,18 @@ func TestE2EFunctionRun(t *testing.T) {
 	encryptedPayload := map[string]any{}
 
 	encrypted, err := client.EncryptString("hello")
-	if err != nil {
-		t.Errorf("error encrypting string %s", err)
-		return
-	}
+	require.NoError(t, err)
+
 	encryptedPayload["String"] = encrypted
 
 	encrypted, err = client.EncryptInt(1)
-	if err != nil {
-		t.Errorf("error encrypting integer %s", err)
-		return
-	}
+	require.NoError(t, err)
+
 	encryptedPayload["Integer"] = encrypted
 
 	encrypted, err = client.EncryptFloat64(1.5)
-	if err != nil {
-		t.Errorf("error encrypting float %s", err)
-		return
-	}
+	require.NoError(t, err)
+
 	encryptedPayload["Float"] = encrypted
 
 	encrypted, err = client.EncryptBool(true)
@@ -50,17 +45,12 @@ func TestE2EFunctionRun(t *testing.T) {
 	encryptedPayload["True"] = encrypted
 
 	encrypted, err = client.EncryptBool(false)
-	if err != nil {
-		t.Errorf("error encrypting false %s", err)
-		return
-	}
+	require.NoError(t, err)
+
 	encryptedPayload["False"] = encrypted
 
 	runResult, err := client.RunFunction(functionName, encryptedPayload)
-	if err != nil {
-		t.Errorf("error running function %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if runResult.Status != "success" {
 		t.Errorf("Expected success, got %s", runResult.Status)
@@ -81,11 +71,9 @@ func TestE2EFunctionRunWithError(t *testing.T) {
 	payload := map[string]any{"shouldError": true}
 
 	_, err := client.RunFunction(functionName, payload)
-	if runtimeError, ok := err.(evervault.FunctionRuntimeError); !ok {
-		t.Error("Expected FunctionRuntimeError, got", err)
-	} else {
-		assert.Equal(t, "User threw an error", runtimeError.ErrorBody.Message)
-	}
+	runtimeError, ok := err.(evervault.FunctionRuntimeError)
+	assert.True(t, ok)
+	assert.Equal(t, "User threw an error", runtimeError.ErrorBody.Message)
 }
 
 func TestE2EFunctionRunWithInitializationError(t *testing.T) {
@@ -96,9 +84,7 @@ func TestE2EFunctionRunWithInitializationError(t *testing.T) {
 	payload := map[string]any{}
 
 	_, err := client.RunFunction(initializationErrorFunctionName, payload)
-	if runtimeError, ok := err.(evervault.FunctionRuntimeError); !ok {
-		t.Error("Expected FunctionRuntimeError, got", err)
-	} else {
-		assert.Equal(t, "The function failed to initialize. This error is commonly encountered when there are problems with the function code (e.g. a syntax error) or when a required import is missing.", runtimeError.ErrorBody.Message)
-	}
+	runtimeError, ok := err.(evervault.FunctionRuntimeError)
+	assert.True(t, ok)
+	assert.Equal(t, "The function failed to initialize. This error is commonly encountered when there are problems with the function code (e.g. a syntax error) or when a required import is missing.", runtimeError.ErrorBody.Message)
 }

--- a/e2e/outbound_e2e_test.go
+++ b/e2e/outbound_e2e_test.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var syntheticEndpointUrl string = os.Getenv("EV_SYNTHETIC_ENDPOINT_URL")
@@ -19,48 +21,27 @@ func TestE2EOutboundRelay(t *testing.T) {
 	client := GetClient(t)
 
 	encryptedString, err := client.EncryptString("some_string")
-	if err != nil {
-		t.Errorf("error encrypting string %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	encryptedNumber, err := client.EncryptInt(1234567890)
-	if err != nil {
-		t.Errorf("error encrypting number %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	encryptedBool, err := client.EncryptBool(true)
-	if err != nil {
-		t.Errorf("error encrypting bool %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	outboundRelayClient, err := client.OutboundRelayClient()
-	if err != nil {
-		t.Errorf("Error getting outbound client %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	data := map[string]string{"string": encryptedString, "number": encryptedNumber, "boolean": encryptedBool}
 
 	payload, err := json.Marshal(data)
-	if err != nil {
-		t.Errorf("error Marshalling payload %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	resp, err := outboundRelayClient.Post(syntheticEndpointUrl, "application/json", bytes.NewReader(payload))
-	if err != nil {
-		t.Errorf("error posting with outbound client %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("error posting with outbound client %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	// close response body
 	resp.Body.Close()

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evervault/evervault-go"
 	"github.com/evervault/evervault-go/attestation"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const enclave = "synthetic-cage.app-f5f084041a7e.enclave.evervault.com"
@@ -32,10 +33,7 @@ func buildEnclaveRequest(t *testing.T, testEnclave string) *http.Request {
 	body := bytes.NewBufferString(`{"test": true}`)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://%s/echo", testEnclave), body)
-	if err != nil {
-		t.Fatal("Couldnt build enclave request: %w", err)
-		return nil
-	}
+	require.NoError(t, err)
 
 	req.Close = true
 	req.Header.Set("API-KEY", os.Getenv("EV_ENCLAVE_API_KEY"))
@@ -50,10 +48,7 @@ func TestEnclaveClient(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	expectedPCRs := attestation.PCRs{
 		PCR0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -63,20 +58,14 @@ func TestEnclaveClient(t *testing.T) {
 	}
 
 	client, err := testClient.EnclaveClient(enclave, []attestation.PCRs{expectedPCRs})
-	if err != nil {
-		t.Errorf("Error creating enclave client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildEnclaveRequest(t, enclave)
 
 	t.Log("making request", enclave)
 
 	resp, err := client.Do(req)
-	if err != nil {
-		t.Errorf("Error making request: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
@@ -84,16 +73,11 @@ func TestEnclaveClient(t *testing.T) {
 	assert.Contains(resp.Header, "X-Evervault-Ctx")
 
 	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("failed to read response body: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	var jsonResp Echo
-	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
-		t.Errorf("failed to unmarshal response body: %s", err)
-		return
-	}
+	err = json.Unmarshal(respBody, &jsonResp)
+	require.NoError(t, err)
 
 	assert.Equal(jsonResp.Body.Test, true)
 }
@@ -104,30 +88,21 @@ func TestEnclavePartialPCR(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	expectedPCRs := attestation.PCRs{
 		PCR8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
 	}
 
 	enclaveClient, err := testClient.EnclaveClient(enclave, []attestation.PCRs{expectedPCRs})
-	if err != nil {
-		t.Errorf("Error creating enclave client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildEnclaveRequest(t, enclave)
 
 	t.Log("making request", enclave)
 
 	resp, err := enclaveClient.Do(req)
-	if err != nil {
-		t.Errorf("Error making request: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
@@ -135,16 +110,11 @@ func TestEnclavePartialPCR(t *testing.T) {
 	assert.Contains(resp.Header, "X-Evervault-Ctx")
 
 	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("failed to read response body: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	var jsonResp Echo
-	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
-		t.Errorf("failed to unmarshal response body: %s", err)
-		return
-	}
+	err = json.Unmarshal(respBody, &jsonResp)
+	require.NoError(t, err)
 
 	assert.Equal(jsonResp.Body.Test, true)
 }
@@ -155,26 +125,17 @@ func TestEnclavePartialPCRProvider(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	enclaveClient, err := testClient.EnclaveClientWithProvider(enclave, GetPCRData)
-	if err != nil {
-		t.Errorf("Error creating enclave client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildEnclaveRequest(t, enclave)
 
 	t.Log("making request", enclave)
 
 	resp, err := enclaveClient.Do(req)
-	if err != nil {
-		t.Errorf("Error making request: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	defer resp.Body.Close()
 
@@ -182,16 +143,11 @@ func TestEnclavePartialPCRProvider(t *testing.T) {
 	assert.Contains(resp.Header, "X-Evervault-Ctx")
 
 	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Errorf("failed to read response body: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	var jsonResp Echo
-	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
-		t.Errorf("failed to unmarshal response body: %s", err)
-		return
-	}
+	err = json.Unmarshal(respBody, &jsonResp)
+	require.NoError(t, err)
 
 	assert.Equal(jsonResp.Body.Test, true)
 }
@@ -202,16 +158,10 @@ func TestEnclaveFailsOnPartialIncorrectPCRProvider(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	enclaveClient, err := testClient.EnclaveClientWithProvider(enclave, GetInvalidPCRData)
-	if err != nil {
-		t.Errorf("Error creating enclave client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildEnclaveRequest(t, enclave)
 
@@ -231,10 +181,7 @@ func TestEnclaveFailsOnPartialIncorrectPCR(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	expectedPCRs := attestation.PCRs{
 		PCR0: "111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
@@ -242,10 +189,7 @@ func TestEnclaveFailsOnPartialIncorrectPCR(t *testing.T) {
 	}
 
 	enclaveClient, err := testClient.EnclaveClient(enclave, []attestation.PCRs{expectedPCRs})
-	if err != nil {
-		t.Errorf("Error creating enclave client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	req := buildEnclaveRequest(t, enclave)
 
@@ -265,10 +209,7 @@ func TestEnclaveRequiresPCR(t *testing.T) {
 	assert := assert.New(t)
 
 	testClient, err := makeTestClient(t)
-	if err != nil {
-		t.Errorf("Error creating evervault client: %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	_, err = testClient.EnclaveClient(enclave, []attestation.PCRs{})
 	assert.ErrorIs(err, evervault.ErrNoPCRs)

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/evervault/evervault-go"
 	"github.com/evervault/evervault-go/internal/crypto"
 	"github.com/evervault/evervault-go/internal/datatypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecryptString(t *testing.T) {
@@ -34,10 +36,7 @@ func TestDecryptString(t *testing.T) {
 	stringType := reflect.TypeOf("")
 
 	res, err := testClient.DecryptString("ev:abc123")
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if reflect.TypeOf(res) != stringType {
 		t.Errorf("Expected decrypted string, got %s", reflect.TypeOf(res))
@@ -55,10 +54,7 @@ func TestDecryptInt(t *testing.T) {
 	intType := reflect.TypeOf(1)
 
 	res, err := testClient.DecryptInt("ev:abc123")
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if reflect.TypeOf(res) != intType {
 		t.Errorf("Expected decrypted int, got %s", reflect.TypeOf(res))
@@ -76,10 +72,7 @@ func TestDecryptFloat64(t *testing.T) {
 	float64Type := reflect.TypeOf(1.1)
 
 	res, err := testClient.DecryptFloat64("ev:abc123")
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if reflect.TypeOf(res) != float64Type {
 		t.Errorf("Expected decrypted float64, got %s", reflect.TypeOf(res))
@@ -97,10 +90,7 @@ func TestDecryptBoolean(t *testing.T) {
 	booleanType := reflect.TypeOf(true)
 
 	res, err := testClient.DecryptBool("ev:abc123")
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if reflect.TypeOf(res) != booleanType {
 		t.Errorf("Expected decrypted bool, got %s", reflect.TypeOf(res))
@@ -118,10 +108,7 @@ func TestDecryptByteArray(t *testing.T) {
 	byteArrayType := reflect.TypeOf([]byte("Hello World!"))
 
 	res, err := testClient.DecryptByteArray("ev:abc123")
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if reflect.TypeOf(res) != byteArrayType {
 		t.Errorf("Expected decrypted byte array, got %s", reflect.TypeOf(res))
@@ -139,10 +126,7 @@ func TestDecryptJsonResponse(t *testing.T) {
 	byteArrayType := reflect.TypeOf([]byte("Hello World!"))
 
 	res, err := testClient.DecryptByteArray("ev:abc123")
-	if err != nil {
-		t.Errorf("error decrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if reflect.TypeOf(res) != byteArrayType {
 		t.Errorf("Expected decrypted byte array, got %s", reflect.TypeOf(res))
@@ -166,10 +150,7 @@ func TestCreateClientSideDecryptToken(t *testing.T) {
 	expiry := time.Now()
 
 	res, err := testClient.CreateClientSideDecryptToken(EncryptedCardData{"4242", "111", "01/23"}, expiry)
-	if err != nil {
-		t.Errorf("error creating decrypt token %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if res.Token != "abcdefghij1234567890" {
 		t.Errorf("Expected token, got %s", res.Token)
@@ -189,14 +170,9 @@ func TestEncryptString(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptString("plaintext")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.String) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.String)
 }
 
 func TestEncryptStringWithRole(t *testing.T) {
@@ -208,14 +184,9 @@ func TestEncryptStringWithRole(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptStringWithDataRole("plaintext", "role")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.String) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.String)
 }
 
 func TestEncryptInt(t *testing.T) {
@@ -227,14 +198,9 @@ func TestEncryptInt(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptInt(123)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.Number) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.Number)
 }
 
 func TestEncryptIntWithRole(t *testing.T) {
@@ -246,14 +212,9 @@ func TestEncryptIntWithRole(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptIntWithDataRole(123, "role")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.Number) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.Number)
 }
 
 func TestEncryptFloat64(t *testing.T) {
@@ -265,14 +226,9 @@ func TestEncryptFloat64(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptFloat64(1.1)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.Number) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.Number)
 }
 
 func TestEncryptFloat64WithRole(t *testing.T) {
@@ -284,14 +240,9 @@ func TestEncryptFloat64WithRole(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptFloat64WithDataRole(1.1, "role")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.Number) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.Number)
 }
 
 func TestEncryptBoolean(t *testing.T) {
@@ -303,14 +254,9 @@ func TestEncryptBoolean(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptBool(true)
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.Boolean) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.Boolean)
 }
 
 func TestEncryptBooleanWithRole(t *testing.T) {
@@ -322,14 +268,9 @@ func TestEncryptBooleanWithRole(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptBoolWithDataRole(true, "role")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.Boolean) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.Boolean)
 }
 
 func TestEncryptByte(t *testing.T) {
@@ -341,14 +282,9 @@ func TestEncryptByte(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptByteArray([]byte("plaintext"))
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.String) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.String)
 }
 
 func TestEncryptByteWithRole(t *testing.T) {
@@ -360,14 +296,9 @@ func TestEncryptByteWithRole(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.EncryptByteArrayWithDataRole([]byte("plaintext"), "role")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
-	if !isValidEncryptedString(res, datatypes.String) {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	assertIsValidEncryptedString(t, res, datatypes.String)
 }
 
 func TestClientInitClientErrorWithoutApiKey(t *testing.T) {
@@ -377,16 +308,10 @@ func TestClientInitClientErrorWithoutApiKey(t *testing.T) {
 	defer server.Close()
 
 	_, err := evervault.MakeClient("", "")
-
-	if err.Error() != evervault.ErrAppCredentialsRequired.Error() {
-		t.Errorf("Unexpected error, got error message %s", err)
-		return
-	}
+	assert.ErrorIs(t, err, evervault.ErrAppCredentialsRequired)
 
 	_, err = evervault.MakeCustomClient("test_api_key", "", evervault.MakeConfig())
-	if err.Error() != evervault.ErrAppCredentialsRequired.Error() {
-		t.Errorf("Unexpected error, got error message %s", err)
-	}
+	assert.ErrorIs(t, err, evervault.ErrAppCredentialsRequired)
 }
 
 func testFuncHandler(writer http.ResponseWriter, reader *http.Request, mockResponse any) {
@@ -549,26 +474,19 @@ func mockedClient(t *testing.T, server *httptest.Server) *evervault.Client {
 	}
 
 	client, err := evervault.MakeCustomClient("test_api_key", "test_app_uuid", config)
-	if err != nil {
-		t.Fail()
-	}
+	require.NoError(t, err)
 
 	return client
 }
 
-func isValidEncryptedString(encryptedString string, datatype datatypes.Datatype) bool {
+func assertIsValidEncryptedString(t *testing.T, encryptedString string, datatype datatypes.Datatype) {
 	parts := strings.Split(encryptedString, ":")
-	if len(parts) < 6 {
-		return false
-	}
+	assert.False(t, len(parts) < 6)
 
 	if datatype == datatypes.Number || datatype == datatypes.Boolean {
 		correctDataType := parts[2] == "number" || parts[2] == "boolean"
 
-		if len(parts) < 7 && !correctDataType {
-			return false
-		}
+		assert.False(t, len(parts) < 7)
+		assert.True(t, correctDataType)
 	}
-
-	return true
 }

--- a/example_test.go
+++ b/example_test.go
@@ -54,7 +54,7 @@ func Example() {
 }
 
 // Example encrypting data locally.
-func ExampleClient_Encrypt() {
+func ExampleClient_EncryptString() {
 	evClient, err := evervault.MakeClient(os.Getenv("EV_APP_UUID"), os.Getenv("EV_API_KEY"))
 	if err != nil {
 		log.Fatal(err)

--- a/function_test.go
+++ b/function_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evervault/evervault-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetFunctionRunToken(t *testing.T) {
@@ -19,10 +20,7 @@ func TestGetFunctionRunToken(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	res, err := testClient.CreateFunctionRunToken("test_function", "test_payload")
-	if err != nil {
-		t.Errorf("Failed to create run token, got %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	if res.Token != "test_token" {
 		t.Errorf("Expected encrypted string, got %s", res)
@@ -48,10 +46,7 @@ func TestRunFunctionSuccess(t *testing.T) {
 	payload := map[string]any{"name": "john", "age": 30}
 
 	res, err := testClient.RunFunction("test_function", payload)
-	if err != nil {
-		t.Errorf("Failed to run Function, got %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	assert.Equal(t, "success", res.Status)
 	assert.Equal(t, id, res.ID)
@@ -78,13 +73,12 @@ func TestRunFunctionFailure(t *testing.T) {
 	payload := map[string]any{"name": "john", "age": 30}
 
 	_, err := testClient.RunFunction("test_function", payload)
-	if runtimeError, ok := err.(evervault.FunctionRuntimeError); !ok {
-		t.Error("Expected FunctionRuntimeError, got", err)
-	} else {
-		assert.Equal(t, message, runtimeError.ErrorBody.Message)
-		assert.Equal(t, stack, runtimeError.ErrorBody.Stack)
-		assert.Equal(t, id, runtimeError.ID)
-	}
+
+	runtimeError, ok := err.(evervault.FunctionRuntimeError)
+	assert.True(t, ok)
+	assert.Equal(t, message, runtimeError.ErrorBody.Message)
+	assert.Equal(t, stack, runtimeError.ErrorBody.Stack)
+	assert.Equal(t, id, runtimeError.ID)
 }
 
 func TestRunFunctionTimeout(t *testing.T) {
@@ -106,11 +100,9 @@ func TestRunFunctionTimeout(t *testing.T) {
 	payload := map[string]any{"name": "john", "age": 30}
 
 	_, err := testClient.RunFunction("test_function", payload)
-	if functionTimeoutError, ok := err.(evervault.FunctionTimeoutError); !ok {
-		t.Error("Expected FunctionTimeoutError, got", err)
-	} else {
-		assert.Equal(t, message, functionTimeoutError.Message)
-	}
+	functionTimeoutError, ok := err.(evervault.FunctionTimeoutError)
+	assert.True(t, ok)
+	assert.Equal(t, message, functionTimeoutError.Message)
 }
 
 func TestRunFunctionNotReady(t *testing.T) {
@@ -132,11 +124,9 @@ func TestRunFunctionNotReady(t *testing.T) {
 	payload := map[string]any{"name": "john", "age": 30}
 
 	_, err := testClient.RunFunction("test_function", payload)
-	if functionNotReadyError, ok := err.(evervault.FunctionNotReadyError); !ok {
-		t.Error("Expected FunctionNotReadyError, got", err)
-	} else {
-		assert.Equal(t, message, functionNotReadyError.Message)
-	}
+	functionNotReadyError, ok := err.(evervault.FunctionNotReadyError)
+	assert.True(t, ok)
+	assert.Equal(t, message, functionNotReadyError.Message)
 }
 
 func TestRunFunctionUnauthorized(t *testing.T) {
@@ -159,10 +149,8 @@ func TestRunFunctionUnauthorized(t *testing.T) {
 	payload := map[string]any{"name": "john", "age": 30}
 
 	_, err := testClient.RunFunction("test_function", payload)
-	if evervaultError, ok := err.(evervault.APIError); !ok {
-		t.Error("Expected Evervault Error, got", err)
-	} else {
-		assert.Equal(t, code, evervaultError.Code)
-		assert.Equal(t, message, evervaultError.Message)
-	}
+	evervaultError, ok := err.(evervault.APIError)
+	assert.True(t, ok)
+	assert.Equal(t, code, evervaultError.Code)
+	assert.Equal(t, message, evervaultError.Message)
 }

--- a/internal/attestation/attestation_cache.go
+++ b/internal/attestation/attestation_cache.go
@@ -98,6 +98,7 @@ func (c *Cache) getDoc(ctx context.Context) ([]byte, error) {
 				lastErr = c.handleError("could not get attestation doc", respErr, attempt)
 				continue
 			}
+			//nolint:errcheck
 			defer resp.Body.Close()
 
 			var response CageDocResponse

--- a/relay_test.go
+++ b/relay_test.go
@@ -10,6 +10,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOutboundClientRoutesToOutboundRelay(t *testing.T) {
@@ -23,9 +26,8 @@ func TestOutboundClientRoutesToOutboundRelay(t *testing.T) {
 		writer.WriteHeader(http.StatusOK)
 		writer.Header().Set("Content-Type", "application/json")
 
-		if err := json.NewEncoder(writer).Encode("OK"); err != nil {
-			t.Errorf("Failed to encode response %s", err)
-		}
+		err := json.NewEncoder(writer).Encode("OK")
+		require.NoError(t, err)
 	}))
 
 	defer mockRelayServer.Close()
@@ -34,26 +36,17 @@ func TestOutboundClientRoutesToOutboundRelay(t *testing.T) {
 	testClient := mockedClient(t, server)
 
 	relayClient, err := testClient.OutboundRelayClient()
-	if err != nil {
-		t.Errorf("Fialed to build oubound client, got %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	ctx := context.Background()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
-	if err != nil {
-		t.Fatal("failed to build get request: %w", err)
-	}
+	require.NoError(t, err)
 
 	resp, err := relayClient.Do(req)
-	if err != nil {
-		t.Errorf("Expected status code 200, got %s", err)
-	}
+	require.NoError(t, err)
 
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
-	}
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
 
 	resp.Body.Close()
 }


### PR DESCRIPTION
# Why

Our tests are littered with `err != nil` checks and conditional failures. We should be using the tooling already supported by `testify` to handle this.

# How

Replace all `err != nil` checks with `require.NoError`
