### PR TITLE
Update CI to support Go 1.24,1.25

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: ['1.20', '1.21']
+        go: ['1.24','1.25']
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: E2E
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.24','1.25']
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -301,6 +301,16 @@ func TestEncryptByteWithRole(t *testing.T) {
 	assertIsValidEncryptedString(t, res, datatypes.String)
 }
 
+func TestCustomClientInitClientErrorWithoutApiKey(t *testing.T) {
+	t.Parallel()
+
+	server := startMockHTTPServer("", "")
+	defer server.Close()
+
+	_, err := evervault.MakeCustomClient("test_api_key", "", evervault.MakeConfig())
+	require.ErrorIs(t, err, evervault.ErrAppCredentialsRequired)
+}
+
 func TestClientInitClientErrorWithoutApiKey(t *testing.T) {
 	t.Parallel()
 
@@ -308,10 +318,7 @@ func TestClientInitClientErrorWithoutApiKey(t *testing.T) {
 	defer server.Close()
 
 	_, err := evervault.MakeClient("", "")
-	assert.ErrorIs(t, err, evervault.ErrAppCredentialsRequired)
-
-	_, err = evervault.MakeCustomClient("test_api_key", "", evervault.MakeConfig())
-	assert.ErrorIs(t, err, evervault.ErrAppCredentialsRequired)
+	require.ErrorIs(t, err, evervault.ErrAppCredentialsRequired)
 }
 
 func testFuncHandler(writer http.ResponseWriter, reader *http.Request, mockResponse any) {


### PR DESCRIPTION
# Why

Go 1.20 is no longer actively maintained

# How

Update CI matrix to consider the 2 latest versions.
