### PR TITLE
Add tooling to avoid the tests running when required env vars are unset

### DIFF
--- a/cage_test.go
+++ b/cage_test.go
@@ -8,11 +8,11 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/evervault/evervault-go"
 	"github.com/evervault/evervault-go/attestation"
+	"github.com/evervault/evervault-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,12 +36,12 @@ func (b Body) String() string {
 func makeTestClient(t *testing.T) (*evervault.Client, error) {
 	t.Helper()
 
-	appUUID := os.Getenv("EV_APP_UUID")
+	appUUID := testhelper.LoadRequiredEnv(t, "EV_APP_UUID")
 	if appUUID == "" {
 		t.Skip("Skipping testing when no app uuid provided")
 	}
 
-	apiKey := os.Getenv("EV_ENCLAVE_API_KEY")
+	apiKey := testhelper.LoadRequiredEnv(t, "EV_ENCLAVE_API_KEY")
 	if apiKey == "" {
 		t.Skip("Skipping testing when no API key provided")
 	}
@@ -59,7 +59,7 @@ func buildCageRequest(t *testing.T, testCage string) *http.Request {
 	require.NoError(t, err)
 
 	req.Close = true
-	req.Header.Set("API-KEY", os.Getenv("EV_ENCLAVE_API_KEY"))
+	req.Header.Set("API-KEY", testhelper.LoadRequiredEnv(t, "EV_ENCLAVE_API_KEY"))
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	return req

--- a/e2e/e2e_helper_test.go
+++ b/e2e/e2e_helper_test.go
@@ -1,10 +1,10 @@
 package e2e_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/evervault/evervault-go"
+	"github.com/evervault/evervault-go/internal/testhelper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,9 +16,9 @@ func GetClient(t *testing.T) *evervault.Client {
 		t.Skip("short was provided when running the test command. Skipping e2e tests.")
 	}
 
-	appUUID := os.Getenv("EV_APP_UUID")
+	appUUID := testhelper.LoadRequiredEnv(t, "EV_APP_UUID")
 
-	apiKey := os.Getenv("EV_API_KEY")
+	apiKey := testhelper.LoadRequiredEnv(t, "EV_API_KEY")
 
 	client, err := evervault.MakeClient(appUUID, apiKey)
 	require.NoError(t, err)

--- a/e2e/function_e2e_test.go
+++ b/e2e/function_e2e_test.go
@@ -1,21 +1,19 @@
 package e2e_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/evervault/evervault-go"
+	"github.com/evervault/evervault-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var functionName string = os.Getenv("EV_FUNCTION_NAME")
-var initializationErrorFunctionName string = os.Getenv("EV_INITIALIZATION_ERROR_FUNCTION_NAME")
 
 func TestE2EFunctionRun(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
+	functionName := testhelper.LoadRequiredEnv(t, "EV_FUNCTION_NAME")
 
 	encryptedPayload := map[string]any{}
 
@@ -64,6 +62,7 @@ func TestE2EFunctionRunWithError(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
+	functionName := testhelper.LoadRequiredEnv(t, "EV_FUNCTION_NAME")
 
 	payload := map[string]any{"shouldError": true}
 
@@ -77,6 +76,7 @@ func TestE2EFunctionRunWithInitializationError(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
+	initializationErrorFunctionName := testhelper.LoadRequiredEnv(t, "EV_INITIALIZATION_ERROR_FUNCTION_NAME")
 
 	payload := map[string]any{}
 

--- a/e2e/outbound_e2e_test.go
+++ b/e2e/outbound_e2e_test.go
@@ -5,18 +5,17 @@ import (
 	"encoding/json"
 	"io"
 	"log"
-	"os"
 	"testing"
 
+	"github.com/evervault/evervault-go/internal/testhelper"
 	"github.com/stretchr/testify/require"
 )
-
-var syntheticEndpointUrl string = os.Getenv("EV_SYNTHETIC_ENDPOINT_URL")
 
 func TestE2EOutboundRelay(t *testing.T) {
 	t.Parallel()
 
 	client := GetClient(t)
+	syntheticEndpointUrl := testhelper.LoadRequiredEnv(t, "EV_SYNTHETIC_ENDPOINT_URL")
 
 	encryptedString, err := client.EncryptString("some_string")
 	require.NoError(t, err)

--- a/enclave_test.go
+++ b/enclave_test.go
@@ -8,11 +8,11 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/evervault/evervault-go"
 	"github.com/evervault/evervault-go/attestation"
+	"github.com/evervault/evervault-go/internal/testhelper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ func buildEnclaveRequest(t *testing.T, testEnclave string) *http.Request {
 	require.NoError(t, err)
 
 	req.Close = true
-	req.Header.Set("API-KEY", os.Getenv("EV_ENCLAVE_API_KEY"))
+	req.Header.Set("API-KEY", testhelper.LoadRequiredEnv(t, "EV_ENCLAVE_API_KEY"))
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	return req

--- a/internal/testhelper/env_loader.go
+++ b/internal/testhelper/env_loader.go
@@ -1,0 +1,14 @@
+package testhelper
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func LoadRequiredEnv(t *testing.T, key string) string {
+	value, isSet := os.LookupEnv(key)
+	require.Truef(t, isSet, "Expected required env var %s to be set", key)
+	return value
+}


### PR DESCRIPTION
# Why

The tests for this SDK, regrettably, rely on _many_ environment variables. We should move away from this pattern in future, but in the interim we need to make sure that the tests don't try to run outside of correctly configured environments.

# How

Introduce `internal/testhelper` with `LoadRequiredEnv` which will fail a test if the requested env var wasn't set
