### PR TITLE
Remove conditional test errors in favour of assertions

### DIFF
--- a/cage_test.go
+++ b/cage_test.go
@@ -104,10 +104,8 @@ func TestCageClient(t *testing.T) {
 	require.NoError(t, err)
 
 	var jsonResp CageEcho
-	if err = json.Unmarshal(respBody, &jsonResp); err != nil {
-		t.Errorf("failed to unmarshal response body: %s", err)
-		return
-	}
+	err = json.Unmarshal(respBody, &jsonResp)
+	require.NoError(t, err)
 
 	assert.Equal(jsonResp.Body.Test, true)
 }

--- a/e2e/encrypt_e2e_test.go
+++ b/e2e/encrypt_e2e_test.go
@@ -19,10 +19,7 @@ func TestE2EEncryptString(t *testing.T) {
 	decrypted, err := client.DecryptString(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %s %s", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptStringWithPermittedRole(t *testing.T) {
@@ -33,18 +30,12 @@ func TestE2EEncryptStringWithPermittedRole(t *testing.T) {
 	payload := "hello world"
 
 	encrypted, err := client.EncryptStringWithDataRole(payload, "permit-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptString(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %s %s", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptStringWithDeniedRole(t *testing.T) {
@@ -74,10 +65,7 @@ func TestE2EEncryptBoolTrue(t *testing.T) {
 	decrypted, err := client.DecryptBool(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptBoolTrueWithPermittedRole(t *testing.T) {
@@ -93,10 +81,7 @@ func TestE2EEncryptBoolTrueWithPermittedRole(t *testing.T) {
 	decrypted, err := client.DecryptBool(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptBoolTrueWithDeniedRole(t *testing.T) {
@@ -126,10 +111,7 @@ func TestE2EEncryptBoolFalse(t *testing.T) {
 	decrypted, err := client.DecryptBool(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptBoolFalseWithPermittedRole(t *testing.T) {
@@ -145,10 +127,7 @@ func TestE2EEncryptBoolFalseWithPermittedRole(t *testing.T) {
 	decrypted, err := client.DecryptBool(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %t %t", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptBoolFalseWithDeniedRole(t *testing.T) {
@@ -178,10 +157,7 @@ func TestE2EEncryptInt(t *testing.T) {
 	decrypted, err := client.DecryptInt(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %d %d", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptIntWithPermittedRole(t *testing.T) {
@@ -197,10 +173,7 @@ func TestE2EEncryptIntWithPermittedRole(t *testing.T) {
 	decrypted, err := client.DecryptInt(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %d %d", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptIntWithDeniedRole(t *testing.T) {
@@ -230,10 +203,7 @@ func TestE2EEncryptFloat(t *testing.T) {
 	decrypted, err := client.DecryptFloat64(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %f %f", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 
 func TestE2EEncryptFloatWithPermittedRole(t *testing.T) {
@@ -244,18 +214,12 @@ func TestE2EEncryptFloatWithPermittedRole(t *testing.T) {
 	payload := 1.5
 
 	encrypted, err := client.EncryptFloat64WithDataRole(payload, "permit-all")
-	if err != nil {
-		t.Errorf("error encrypting data %s", err)
-		return
-	}
+	require.NoError(t, err)
 
 	decrypted, err := client.DecryptFloat64(encrypted)
 	require.NoError(t, err)
 
-	if payload != decrypted {
-		t.Errorf("decrypted data does not match the original %f %f", payload, decrypted)
-		return
-	}
+	require.Equal(t, payload, decrypted)
 }
 func TestE2EEncryptFloatWithDeniedRole(t *testing.T) {
 	t.Parallel()
@@ -286,10 +250,7 @@ func TestE2EEncryptBytes(t *testing.T) {
 	decrypted, err := client.DecryptByteArray(encrypted)
 	require.NoError(t, err)
 
-	if string(payload) != string(decrypted) {
-		t.Errorf("decrypted data does not match the original %s %s", string(payload), string(decrypted))
-		return
-	}
+	require.Equal(t, string(payload), string(decrypted))
 }
 
 func TestE2EEncryptBytesWithPermittedRole(t *testing.T) {
@@ -307,10 +268,7 @@ func TestE2EEncryptBytesWithPermittedRole(t *testing.T) {
 	decrypted, err := client.DecryptByteArray(encrypted)
 	require.NoError(t, err)
 
-	if string(payload) != string(decrypted) {
-		t.Errorf("decrypted data does not match the original %s %s", string(payload), string(decrypted))
-		return
-	}
+	require.Equal(t, string(payload), string(decrypted))
 }
 
 func TestE2EEncryptBytesWithDeniedRole(t *testing.T) {

--- a/e2e/function_e2e_test.go
+++ b/e2e/function_e2e_test.go
@@ -33,10 +33,8 @@ func TestE2EFunctionRun(t *testing.T) {
 	encryptedPayload["Float"] = encrypted
 
 	encrypted, err = client.EncryptBool(true)
-	if err != nil {
-		t.Errorf("error encrypting true %s", err)
-		return
-	}
+	require.NoError(t, err)
+
 	encryptedPayload["True"] = encrypted
 
 	encrypted, err = client.EncryptBool(false)
@@ -47,10 +45,7 @@ func TestE2EFunctionRun(t *testing.T) {
 	runResult, err := client.RunFunction(functionName, encryptedPayload)
 	require.NoError(t, err)
 
-	if runResult.Status != "success" {
-		t.Errorf("Expected success, got %s", runResult.Status)
-	}
-
+	assert.Equal(t, runResult.Status, "success")
 	assert.Equal(t, "string", runResult.Result["String"])
 	assert.Equal(t, "number", runResult.Result["Integer"])
 	assert.Equal(t, "number", runResult.Result["Float"])

--- a/e2e/outbound_e2e_test.go
+++ b/e2e/outbound_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/evervault/evervault-go/internal/testhelper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,18 +52,7 @@ func TestE2EOutboundRelay(t *testing.T) {
 	//nolint:errcheck
 	_ = json.Unmarshal(body, &responseData)
 
-	if responseData["request"]["string"] != false {
-		t.Errorf("Expected false as response %t", responseData["request"]["string"])
-		return
-	}
-
-	if responseData["request"]["number"] != false {
-		t.Errorf("Expected false as response %t", responseData["request"]["number"])
-		return
-	}
-
-	if responseData["request"]["boolean"] != false {
-		t.Errorf("Expected false as response %t", responseData["request"]["boolean"])
-		return
-	}
+	assert.Falsef(t, responseData["request"]["string"], "Expected false as a response: %t", responseData["request"]["string"])
+	assert.Falsef(t, responseData["request"]["number"], "Expected false as a response: %t", responseData["request"]["number"])
+	assert.Falsef(t, responseData["request"]["boolean"], "Expected false as a response: %t", responseData["request"]["boolean"])
 }

--- a/e2e/outbound_e2e_test.go
+++ b/e2e/outbound_e2e_test.go
@@ -52,7 +52,7 @@ func TestE2EOutboundRelay(t *testing.T) {
 	//nolint:errcheck
 	_ = json.Unmarshal(body, &responseData)
 
-	assert.Falsef(t, responseData["request"]["string"], "Expected false as a response: %t", responseData["request"]["string"])
-	assert.Falsef(t, responseData["request"]["number"], "Expected false as a response: %t", responseData["request"]["number"])
-	assert.Falsef(t, responseData["request"]["boolean"], "Expected false as a response: %t", responseData["request"]["boolean"])
+	assert.False(t, responseData["request"]["string"])
+	assert.False(t, responseData["request"]["number"])
+	assert.False(t, responseData["request"]["boolean"])
 }

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -35,9 +35,7 @@ func TestDecryptString(t *testing.T) {
 	res, err := testClient.DecryptString("ev:abc123")
 	require.NoError(t, err)
 
-	if reflect.TypeOf(res) != stringType {
-		t.Errorf("Expected decrypted string, got %s", reflect.TypeOf(res))
-	}
+	require.Equal(t, reflect.TypeOf(res), stringType)
 }
 
 func TestDecryptInt(t *testing.T) {
@@ -53,9 +51,7 @@ func TestDecryptInt(t *testing.T) {
 	res, err := testClient.DecryptInt("ev:abc123")
 	require.NoError(t, err)
 
-	if reflect.TypeOf(res) != intType {
-		t.Errorf("Expected decrypted int, got %s", reflect.TypeOf(res))
-	}
+	require.Equal(t, reflect.TypeOf(res), intType)
 }
 
 func TestDecryptFloat64(t *testing.T) {
@@ -71,9 +67,7 @@ func TestDecryptFloat64(t *testing.T) {
 	res, err := testClient.DecryptFloat64("ev:abc123")
 	require.NoError(t, err)
 
-	if reflect.TypeOf(res) != float64Type {
-		t.Errorf("Expected decrypted float64, got %s", reflect.TypeOf(res))
-	}
+	require.Equal(t, reflect.TypeOf(res), float64Type)
 }
 
 func TestDecryptBoolean(t *testing.T) {
@@ -89,9 +83,7 @@ func TestDecryptBoolean(t *testing.T) {
 	res, err := testClient.DecryptBool("ev:abc123")
 	require.NoError(t, err)
 
-	if reflect.TypeOf(res) != booleanType {
-		t.Errorf("Expected decrypted bool, got %s", reflect.TypeOf(res))
-	}
+	require.Equal(t, reflect.TypeOf(res), booleanType)
 }
 
 func TestDecryptByteArray(t *testing.T) {
@@ -107,9 +99,7 @@ func TestDecryptByteArray(t *testing.T) {
 	res, err := testClient.DecryptByteArray("ev:abc123")
 	require.NoError(t, err)
 
-	if reflect.TypeOf(res) != byteArrayType {
-		t.Errorf("Expected decrypted byte array, got %s", reflect.TypeOf(res))
-	}
+	require.Equal(t, reflect.TypeOf(res), byteArrayType)
 }
 
 func TestDecryptJsonResponse(t *testing.T) {
@@ -125,9 +115,7 @@ func TestDecryptJsonResponse(t *testing.T) {
 	res, err := testClient.DecryptByteArray("ev:abc123")
 	require.NoError(t, err)
 
-	if reflect.TypeOf(res) != byteArrayType {
-		t.Errorf("Expected decrypted byte array, got %s", reflect.TypeOf(res))
-	}
+	require.Equal(t, reflect.TypeOf(res), byteArrayType)
 }
 
 func TestCreateClientSideDecryptToken(t *testing.T) {
@@ -149,13 +137,8 @@ func TestCreateClientSideDecryptToken(t *testing.T) {
 	res, err := testClient.CreateClientSideDecryptToken(EncryptedCardData{"4242", "111", "01/23"}, expiry)
 	require.NoError(t, err)
 
-	if res.Token != "abcdefghij1234567890" {
-		t.Errorf("Expected token, got %s", res.Token)
-	}
-
-	if res.Expiry != expiry.UnixMilli() {
-		t.Errorf("Expected expiry, got %d", res.Expiry)
-	}
+	require.Equal(t, res.Token, "abcdefghij1234567890")
+	require.Equal(t, res.Expiry, expiry.UnixMilli())
 }
 
 func TestEncryptString(t *testing.T) {

--- a/evervault_test.go
+++ b/evervault_test.go
@@ -35,7 +35,7 @@ func TestDecryptString(t *testing.T) {
 	res, err := testClient.DecryptString("ev:abc123")
 	require.NoError(t, err)
 
-	require.Equal(t, reflect.TypeOf(res), stringType)
+	require.Equal(t, stringType, reflect.TypeOf(res),)
 }
 
 func TestDecryptInt(t *testing.T) {
@@ -51,7 +51,7 @@ func TestDecryptInt(t *testing.T) {
 	res, err := testClient.DecryptInt("ev:abc123")
 	require.NoError(t, err)
 
-	require.Equal(t, reflect.TypeOf(res), intType)
+	require.Equal(t, intType, reflect.TypeOf(res))
 }
 
 func TestDecryptFloat64(t *testing.T) {
@@ -67,7 +67,7 @@ func TestDecryptFloat64(t *testing.T) {
 	res, err := testClient.DecryptFloat64("ev:abc123")
 	require.NoError(t, err)
 
-	require.Equal(t, reflect.TypeOf(res), float64Type)
+	require.Equal(t, float64Type, reflect.TypeOf(res))
 }
 
 func TestDecryptBoolean(t *testing.T) {
@@ -83,7 +83,7 @@ func TestDecryptBoolean(t *testing.T) {
 	res, err := testClient.DecryptBool("ev:abc123")
 	require.NoError(t, err)
 
-	require.Equal(t, reflect.TypeOf(res), booleanType)
+	require.Equal(t, booleanType, reflect.TypeOf(res))
 }
 
 func TestDecryptByteArray(t *testing.T) {
@@ -99,7 +99,7 @@ func TestDecryptByteArray(t *testing.T) {
 	res, err := testClient.DecryptByteArray("ev:abc123")
 	require.NoError(t, err)
 
-	require.Equal(t, reflect.TypeOf(res), byteArrayType)
+	require.Equal(t, byteArrayType, reflect.TypeOf(res))
 }
 
 func TestDecryptJsonResponse(t *testing.T) {
@@ -115,7 +115,7 @@ func TestDecryptJsonResponse(t *testing.T) {
 	res, err := testClient.DecryptByteArray("ev:abc123")
 	require.NoError(t, err)
 
-	require.Equal(t, reflect.TypeOf(res), byteArrayType)
+	require.Equal(t, byteArrayType, reflect.TypeOf(res))
 }
 
 func TestCreateClientSideDecryptToken(t *testing.T) {
@@ -137,8 +137,8 @@ func TestCreateClientSideDecryptToken(t *testing.T) {
 	res, err := testClient.CreateClientSideDecryptToken(EncryptedCardData{"4242", "111", "01/23"}, expiry)
 	require.NoError(t, err)
 
-	require.Equal(t, res.Token, "abcdefghij1234567890")
-	require.Equal(t, res.Expiry, expiry.UnixMilli())
+	require.Equal(t, "abcdefghij1234567890", res.Token)
+	require.Equal(t, expiry.UnixMilli(), res.Expiry)
 }
 
 func TestEncryptString(t *testing.T) {

--- a/function_test.go
+++ b/function_test.go
@@ -19,9 +19,7 @@ func TestGetFunctionRunToken(t *testing.T) {
 	res, err := testClient.CreateFunctionRunToken("test_function", "test_payload")
 	require.NoError(t, err)
 
-	if res.Token != "test_token" {
-		t.Errorf("Expected encrypted string, got %s", res)
-	}
+	require.Equal(t, res.Token, "test_token")
 }
 
 func TestRunFunctionSuccess(t *testing.T) {

--- a/function_test.go
+++ b/function_test.go
@@ -19,7 +19,7 @@ func TestGetFunctionRunToken(t *testing.T) {
 	res, err := testClient.CreateFunctionRunToken("test_function", "test_payload")
 	require.NoError(t, err)
 
-	require.Equal(t, res.Token, "test_token")
+	require.Equal(t, "test_token", res.Token)
 }
 
 func TestRunFunctionSuccess(t *testing.T) {


### PR DESCRIPTION
# Why

Many of the SDKs tests used a conditional error path which is quite unusual. We should be using assertions that enforce the expected condition instead.

# How

Replace conditional failures with assertions.
